### PR TITLE
fix: remove custom paddings from secondary bar items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@apollo/client": "~3.5.10",
-				"@zextras/carbonio-design-system": "~0.3.0",
-				"@zextras/carbonio-shell-ui": "~0.4.13",
-				"@zextras/carbonio-ui-preview": "^0.1.4",
+				"@zextras/carbonio-design-system": "~0.3.1",
+				"@zextras/carbonio-shell-ui": "~0.4.15",
+				"@zextras/carbonio-ui-preview": "^0.1.5",
 				"core-js": "^3.21.1",
 				"graphql": "^16.3.0",
 				"lodash": "^4.17.21",
@@ -6204,9 +6204,9 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"node_modules/@zextras/carbonio-design-system": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-0.3.0.tgz",
-			"integrity": "sha512-LQWs41ubVHomxkwsb/EFj2EQn2LZ9tccdEuUsvBL/3J7zjZ1ARgjL+vo29YozmJGKQUkPRAVci9GDfEJZ5jEtQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-0.3.2.tgz",
+			"integrity": "sha512-7uGjG1YxFdFkssSeyIDIQ8l3J63dlhXYNOuni84mFajf68+blaQPqzJyV2W0Mq2BAGLam3exSp6KOKt2H/bb8w==",
 			"dependencies": {
 				"@popperjs/core": "2.11.0",
 				"darkreader": "4.9.44",
@@ -6238,14 +6238,14 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/@zextras/carbonio-shell-ui": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-0.4.13.tgz",
-			"integrity": "sha512-4ymMnqi04gPOdEV5g9dcXP0fNj4RGS17Cgzf7+6ETXZ9iFDOoNO5FQYCQL3Z/iQBDJdeXdJjiir6PKBrOm4QJQ==",
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-0.4.15.tgz",
+			"integrity": "sha512-D8YMm6aPKHdcudeZ6Zv9w9ZeiTZacwIdecqpzFawO82n62pFEOIaz3OQ+dJO9el6K6G20I6SPifLTzV0XZ41zg==",
 			"dependencies": {
 				"@sentry/browser": "^6.17.7",
 				"@tinymce/tinymce-react": "^3.13.0",
-				"@zextras/carbonio-design-system": "^0.3.0",
-				"@zextras/carbonio-ui-preview": "^0.1.4",
+				"@zextras/carbonio-design-system": "0.3.2",
+				"@zextras/carbonio-ui-preview": "^0.1.5",
 				"darkreader": "4.9.44",
 				"history": "^5.2.0",
 				"i18next": "21.6.10",
@@ -6675,9 +6675,10 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-preview": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-0.1.4.tgz",
-			"integrity": "sha512-WdVv38vL4YSJrXPpcdInGUc51eBBC8RhR3WFkyF8oxAFfK/4S1yOzP/BmjsRDxcmmlIqWZF+C3WbRYBuGmX4oA==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-0.1.5.tgz",
+			"integrity": "sha512-LDGhdqigkNNW1K7w5+1vcoND7rNZeJApYSLXIfLLiq/oDD1buStrgOBj6P6TuuRRB/0poJQQF/j+dzVRvACFbg==",
+			"hasInstallScript": true,
 			"dependencies": {
 				"core-js": "3.19.1",
 				"react-pdf": "^5.7.1"
@@ -30465,9 +30466,9 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"@zextras/carbonio-design-system": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-0.3.0.tgz",
-			"integrity": "sha512-LQWs41ubVHomxkwsb/EFj2EQn2LZ9tccdEuUsvBL/3J7zjZ1ARgjL+vo29YozmJGKQUkPRAVci9GDfEJZ5jEtQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-0.3.2.tgz",
+			"integrity": "sha512-7uGjG1YxFdFkssSeyIDIQ8l3J63dlhXYNOuni84mFajf68+blaQPqzJyV2W0Mq2BAGLam3exSp6KOKt2H/bb8w==",
 			"requires": {
 				"@popperjs/core": "2.11.0",
 				"darkreader": "4.9.44",
@@ -30495,14 +30496,14 @@
 			}
 		},
 		"@zextras/carbonio-shell-ui": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-0.4.13.tgz",
-			"integrity": "sha512-4ymMnqi04gPOdEV5g9dcXP0fNj4RGS17Cgzf7+6ETXZ9iFDOoNO5FQYCQL3Z/iQBDJdeXdJjiir6PKBrOm4QJQ==",
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-0.4.15.tgz",
+			"integrity": "sha512-D8YMm6aPKHdcudeZ6Zv9w9ZeiTZacwIdecqpzFawO82n62pFEOIaz3OQ+dJO9el6K6G20I6SPifLTzV0XZ41zg==",
 			"requires": {
 				"@sentry/browser": "^6.17.7",
 				"@tinymce/tinymce-react": "^3.13.0",
-				"@zextras/carbonio-design-system": "^0.3.0",
-				"@zextras/carbonio-ui-preview": "^0.1.4",
+				"@zextras/carbonio-design-system": "0.3.2",
+				"@zextras/carbonio-ui-preview": "^0.1.5",
 				"darkreader": "4.9.44",
 				"history": "^5.2.0",
 				"i18next": "21.6.10",
@@ -30813,9 +30814,9 @@
 			}
 		},
 		"@zextras/carbonio-ui-preview": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-0.1.4.tgz",
-			"integrity": "sha512-WdVv38vL4YSJrXPpcdInGUc51eBBC8RhR3WFkyF8oxAFfK/4S1yOzP/BmjsRDxcmmlIqWZF+C3WbRYBuGmX4oA==",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-0.1.5.tgz",
+			"integrity": "sha512-LDGhdqigkNNW1K7w5+1vcoND7rNZeJApYSLXIfLLiq/oDD1buStrgOBj6P6TuuRRB/0poJQQF/j+dzVRvACFbg==",
 			"requires": {
 				"core-js": "3.19.1",
 				"react-pdf": "^5.7.1"

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
 	},
 	"dependencies": {
 		"@apollo/client": "~3.5.10",
-		"@zextras/carbonio-design-system": "~0.3.0",
-		"@zextras/carbonio-shell-ui": "~0.4.13",
-		"@zextras/carbonio-ui-preview": "^0.1.4",
+		"@zextras/carbonio-design-system": "~0.3.1",
+		"@zextras/carbonio-shell-ui": "~0.4.15",
+		"@zextras/carbonio-ui-preview": "^0.1.5",
 		"core-js": "^3.21.1",
 		"graphql": "^16.3.0",
 		"lodash": "^4.17.21",

--- a/src/views/secondary-bar/secondary-bar.tsx
+++ b/src/views/secondary-bar/secondary-bar.tsx
@@ -31,19 +31,6 @@ import { useNavigation } from '../../hooks/useNavigation';
 const CustomAccordion = styled(Accordion)`
 	justify-content: flex-start;
 	height: 100%;
-	div[class*='AccordionContainer'] {
-		& > div:only-child div[class*='CustomAccordionItem'],
-		& > div[class*='Padding'] {
-			padding-right: 16px;
-		}
-	}
-	/* 
-	 * nested items should have left padding of 16px + (8 * level)
-	 * Since we only have 1 nested level, I'm setting all to 8px
-	 */
-	div[class*='Collapse'] div[class*='AccordionContainer'] {
-		padding-left: 8px;
-	}
 `;
 
 interface ShellSecondaryBarProps {


### PR DESCRIPTION
Following Zextras/carbonio-design-system#52 changes, remove custom paddings in favor of DS ones

refs: FILES-234