### PR TITLE
refactor: change imports of lodash from default to named

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -16,8 +16,7 @@ import {
 	SecondaryBarComponentProps,
 	SearchViewProps
 } from '@zextras/carbonio-shell-ui';
-import filter from 'lodash/filter';
-import size from 'lodash/size';
+import { filter, size } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import buildClient from './carbonio-files-ui-common/apollo';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,7 +8,7 @@ import React from 'react';
 
 import type { QueryChip } from '@zextras/carbonio-shell-ui';
 import { ACTION_TYPES as SHELL_ACTION_TYPES } from '@zextras/carbonio-shell-ui';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 
 export const UpdateQueryContext = React.createContext<(arg: Array<QueryChip>) => void>(() => noop);
 

--- a/src/hooks/useActiveNode.ts
+++ b/src/hooks/useActiveNode.ts
@@ -6,7 +6,7 @@
 
 import { useCallback } from 'react';
 
-import includes from 'lodash/includes';
+import { includes } from 'lodash';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { DISPLAYER_TABS } from '../carbonio-files-ui-common/constants';

--- a/src/hooks/useInternalLink.ts
+++ b/src/hooks/useInternalLink.ts
@@ -7,8 +7,7 @@
 import { useMemo } from 'react';
 
 import { getCurrentRoute } from '@zextras/carbonio-shell-ui';
-import head from 'lodash/head';
-import split from 'lodash/split';
+import { head, split } from 'lodash';
 
 import { FILES_ROUTE } from '../carbonio-files-ui-common/constants';
 import { NodeType } from '../carbonio-files-ui-common/types/graphql/types';

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -8,9 +8,7 @@ import { useCallback, useContext } from 'react';
 
 import { useReactiveVar } from '@apollo/client';
 import type { QueryChip } from '@zextras/carbonio-shell-ui';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import partition from 'lodash/partition';
+import { forEach, map, partition } from 'lodash';
 
 import { searchParamsVar } from '../carbonio-files-ui-common/apollo/searchVar';
 import {

--- a/src/integrations/getGetLinkFunction.ts
+++ b/src/integrations/getGetLinkFunction.ts
@@ -6,8 +6,7 @@
 
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import { AnyFunction, registerFunctions } from '@zextras/carbonio-shell-ui';
-import find from 'lodash/find';
-import map from 'lodash/map';
+import { map, find } from 'lodash';
 
 import buildClient from '../carbonio-files-ui-common/apollo';
 import LINK from '../carbonio-files-ui-common/graphql/fragments/link.graphql';

--- a/src/views/SearchView.tsx
+++ b/src/views/SearchView.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect } from 'react';
 
 import type { QueryChip, SearchViewProps } from '@zextras/carbonio-shell-ui';
-import size from 'lodash/size';
+import { size } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { searchParamsVar } from '../carbonio-files-ui-common/apollo/searchVar';

--- a/src/views/secondary-bar/secondary-bar.tsx
+++ b/src/views/secondary-bar/secondary-bar.tsx
@@ -8,11 +8,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { useReactiveVar } from '@apollo/client';
 import { Accordion, AccordionItemType, Container } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
-import map from 'lodash/map';
-import orderBy from 'lodash/orderBy';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
+import { map, find, reduce, size, orderBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';


### PR DESCRIPTION
Refactor the way imports from lodash are made in order to take advantage of the sdk build, which treats lodash import as external. In this way, the bundle of Files is reduced because it does not include lodash anymore.

refs: FILES-568