### PR TITLE
perf: read parent node from cache in children field

### DIFF
--- a/src/carbonio-files-ui-common/apollo/typePolicies/Folder.ts
+++ b/src/carbonio-files-ui-common/apollo/typePolicies/Folder.ts
@@ -45,7 +45,7 @@ export const folderTypePolicies: TypePolicy = {
 						__typename: typename,
 						id: variables.node_id
 					});
-					if (parentFolderRef && canRead(parentFolderRef)) {
+					if (parentFolderRef) {
 						const parentNode = cache.readFragment<ParentFragment>({
 							fragment: ParentFragmentDoc,
 							fragmentName: 'Parent',

--- a/src/carbonio-files-ui-common/apollo/typePolicies/Folder.ts
+++ b/src/carbonio-files-ui-common/apollo/typePolicies/Folder.ts
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { FieldFunctionOptions, TypePolicy } from '@apollo/client';
+import { forEach } from 'lodash';
 
 import { mergeNodesList, readNodesList } from './utils';
 import { FindNodesCachedObject, NodesPage, NodesPageCachedObject } from '../../types/apollo';
-import { FolderChildrenArgs, GetChildrenQueryVariables } from '../../types/graphql/types';
+import {
+	FolderChildrenArgs,
+	GetChildrenQueryVariables,
+	NodeParentFragment,
+	NodeParentFragmentDoc,
+	ParentFragment,
+	ParentFragmentDoc
+} from '../../types/graphql/types';
+import { findNodeTypeName } from '../cacheUtils';
 
 export const folderTypePolicies: TypePolicy = {
 	fields: {
@@ -21,14 +30,43 @@ export const folderTypePolicies: TypePolicy = {
 					Partial<GetChildrenQueryVariables>
 				>
 			): NodesPageCachedObject {
+				const merged = mergeNodesList(
+					// for filters, if first page is requested, clear cached data emptying existing data
+					fieldFunctions.variables?.page_token ? existing.nodes : { ordered: [], unOrdered: [] },
+					incoming.nodes,
+					fieldFunctions
+				);
+				// update children to set parent field
+				const { variables, toReference, canRead, cache } = fieldFunctions;
+
+				if (variables?.node_id) {
+					const typename = findNodeTypeName(variables.node_id, { canRead, toReference });
+					const parentFolderRef = toReference({
+						__typename: typename,
+						id: variables.node_id
+					});
+					if (parentFolderRef && canRead(parentFolderRef)) {
+						const parentNode = cache.readFragment<ParentFragment>({
+							fragment: ParentFragmentDoc,
+							fragmentName: 'Parent',
+							id: cache.identify(parentFolderRef)
+						});
+						// write parent data on each child
+						forEach([...merged.ordered, ...merged.unOrdered], (child) => {
+							cache.writeFragment<NodeParentFragment>({
+								id: cache.identify(child),
+								fragment: NodeParentFragmentDoc,
+								fragmentName: 'NodeParent',
+								data: {
+									parent: parentNode
+								}
+							});
+						});
+					}
+				}
 				return {
 					page_token: incoming.page_token,
-					nodes: mergeNodesList(
-						// for filters, if first page is requested, clear cached data emptying existing data
-						fieldFunctions.variables?.page_token ? existing.nodes : { ordered: [], unOrdered: [] },
-						incoming.nodes,
-						fieldFunctions
-					)
+					nodes: merged
 				};
 			},
 			// Return all items stored so far, to avoid ambiguities

--- a/src/carbonio-files-ui-common/apollo/typePolicies/fieldPolicies/getNode.ts
+++ b/src/carbonio-files-ui-common/apollo/typePolicies/fieldPolicies/getNode.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { FieldFunctionOptions, FieldPolicy, Reference } from '@apollo/client';
-import { find } from 'lodash';
 
-import introspection from '../../../types/graphql/possible-types';
 import { GetNodeQueryVariables, QueryGetNodeArgs } from '../../../types/graphql/types';
+import { findNodeTypeName } from '../../cacheUtils';
 
 export const getNodeFieldPolicy: FieldPolicy<
 	Reference,
@@ -21,13 +20,7 @@ export const getNodeFieldPolicy: FieldPolicy<
 			GetNodeQueryVariables
 		>;
 		if (args?.node_id) {
-			const typename = find(introspection.possibleTypes.Node, (nodePossibleType) => {
-				const nodeRef = toReference({
-					__typename: nodePossibleType,
-					id: args.node_id
-				});
-				return canRead(nodeRef);
-			});
+			const typename = findNodeTypeName(args.node_id, { canRead, toReference });
 
 			return toReference({
 				__typename: typename,

--- a/src/carbonio-files-ui-common/graphql/fragments/child.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/child.graphql
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 #import "./baseNode.graphql"
-#import "./permissions.graphql"
 #import "./share.graphql"
 
 fragment Child on Node {
@@ -18,11 +17,6 @@ fragment Child on Node {
 		id
 		full_name
 		email
-	}
-	parent {
-		id
-		name
-		...Permissions
 	}
 	shares(limit: $shares_limit) {
 		...Share

--- a/src/carbonio-files-ui-common/graphql/fragments/childWithParent.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/childWithParent.graphql
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+#import "./child.graphql"
+#import "./nodeParent.graphql"
+
+fragment ChildWithParent on Node {
+    ...Child
+    ...NodeParent
+}

--- a/src/carbonio-files-ui-common/graphql/fragments/nodeParent.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/nodeParent.graphql
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+#import "./parent.graphql"
+
+fragment NodeParent on Node {
+    parent {
+        ...Parent
+    }
+}

--- a/src/carbonio-files-ui-common/graphql/fragments/parent.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/parent.graphql
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+#import "./permissions.graphql"
+
+fragment Parent on Node {
+    id
+    name
+    owner {
+        id
+        full_name
+        email
+    }
+    ...Permissions
+}

--- a/src/carbonio-files-ui-common/graphql/mutations/copyNodes.graphql
+++ b/src/carbonio-files-ui-common/graphql/mutations/copyNodes.graphql
@@ -7,5 +7,9 @@
 mutation copyNodes($node_ids: [ID!], $destination_id: ID!, $shares_limit: Int = 1) {
     copyNodes(node_ids: $node_ids, destination_id: $destination_id) {
         ...Child
+        parent {
+            id
+            name
+        }
     }
 }

--- a/src/carbonio-files-ui-common/graphql/mutations/createFolder.graphql
+++ b/src/carbonio-files-ui-common/graphql/mutations/createFolder.graphql
@@ -7,5 +7,9 @@
 mutation createFolder($destination_id: String!, $name: String!, $shares_limit: Int = 1) {
 	createFolder(destination_id: $destination_id, name: $name) {
 		...Child
+		parent {
+			id
+			name
+		}
 	}
 }

--- a/src/carbonio-files-ui-common/graphql/mutations/updateNode.graphql
+++ b/src/carbonio-files-ui-common/graphql/mutations/updateNode.graphql
@@ -7,5 +7,8 @@ mutation updateNode($node_id: String!, $name: String, $description: String) {
 		id
 		name
 		description
+		parent {
+			id
+		}
 	}
 }

--- a/src/carbonio-files-ui-common/graphql/queries/findNodes.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/findNodes.graphql
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-#import "../fragments/child.graphql"
+#import "../fragments/childWithParent.graphql"
 
 query findNodes(
     $keywords: [String!],
@@ -34,7 +34,7 @@ query findNodes(
         type: $type
     ) {
         nodes {
-            ...Child
+            ...ChildWithParent
         }
         page_token
     }

--- a/src/carbonio-files-ui-common/graphql/queries/getChild.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/getChild.graphql
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-#import "../fragments/child.graphql"
+#import "../fragments/childWithParent.graphql"
 
 query getChild(
 	$node_id: ID!,
 	$shares_limit: Int = 1
 ) {
 	getNode(node_id: $node_id) {
-		...Child
+		...ChildWithParent
 	}
 }

--- a/src/carbonio-files-ui-common/graphql/queries/getChildren.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/getChildren.graphql
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 #import "../fragments/child.graphql"
+#import "../fragments/nodeParent.graphql"
+#import "../fragments/parent.graphql"
 
 query getChildren(
 	$node_id: ID!,
@@ -12,12 +14,12 @@ query getChildren(
 	$shares_limit: Int = 1
 ) {
 	getNode(node_id: $node_id) {
-		id
-		name
+		...Parent
 		... on Folder {
 			children(limit: $children_limit, page_token: $page_token, sort: $sort) {
 				nodes {
 					...Child
+					...NodeParent @client
 				}
 				page_token
 			}

--- a/src/carbonio-files-ui-common/graphql/queries/getNode.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/getNode.graphql
@@ -6,6 +6,7 @@
 #import "../fragments/child.graphql"
 #import "../fragments/permissions.graphql"
 #import "../fragments/share.graphql"
+#import "../fragments/nodeParent.graphql"
 
 query getNode($node_id: ID!, $children_limit: Int!, $page_token: String, $sort: NodeSort!, $shares_limit: Int!, $shares_cursor: String, $shares_sorts: [ShareSort!]) {
 	getNode(node_id: $node_id) {
@@ -40,6 +41,7 @@ query getNode($node_id: ID!, $children_limit: Int!, $page_token: String, $sort: 
 			children(limit: $children_limit, page_token: $page_token, sort: $sort) {
 				nodes {
 					...Child
+					...NodeParent @client
 				}
 				page_token
 			}

--- a/src/carbonio-files-ui-common/hooks/graphql/mutations/useUpdateNodeMutation.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/mutations/useUpdateNodeMutation.ts
@@ -11,9 +11,9 @@ import { useParams } from 'react-router-dom';
 
 import { nodeSortVar } from '../../../apollo/nodeSortVar';
 import UPDATE_NODE from '../../../graphql/mutations/updateNode.graphql';
-import GET_CHILDREN from '../../../graphql/queries/getChildren.graphql';
 import {
-	ChildFragmentDoc,
+	ChildWithParentFragmentDoc,
+	GetChildrenDocument,
 	GetChildrenQuery,
 	GetChildrenQueryVariables,
 	UpdateNodeMutation,
@@ -61,13 +61,13 @@ export function useUpdateNodeMutation(): [
 						// if updated node has a parent, check if parent has children in cache
 						// and update node position in parent cached children
 						const updatedNode = cache.readFragment({
-							fragment: ChildFragmentDoc,
-							fragmentName: 'Child',
+							fragment: ChildWithParentFragmentDoc,
+							fragmentName: 'ChildWithParent',
 							id: cache.identify(data.updateNode)
 						});
 						if (updatedNode?.parent) {
 							const parentFolder = cache.readQuery<GetChildrenQuery, GetChildrenQueryVariables>({
-								query: GET_CHILDREN,
+								query: GetChildrenDocument,
 								variables: {
 									node_id: updatedNode.parent.id,
 									// load all cached children

--- a/src/carbonio-files-ui-common/hooks/graphql/useUpdateFolderContent.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/useUpdateFolderContent.ts
@@ -54,21 +54,19 @@ export const useUpdateFolderContent = (
 				return { newPosition: 0, isLast: true };
 			}
 
-			let nodes: Array<Maybe<Node>> = [];
-
-			if (cachedFolder && cachedFolder.getNode && isFolder(cachedFolder.getNode)) {
-				nodes = cachedFolder.getNode.children.nodes;
-			}
+			const nodes: Array<Maybe<Node>> =
+				(isFolder(cachedFolder.getNode) && cachedFolder.getNode.children.nodes) || [];
+			const newNodeWithParent = { ...newNode, parent: cachedFolder.getNode };
 
 			// if folder is empty, just write cache
 			if (nodes.length === 0) {
-				addNodeInCachedChildren(apolloClient.cache, newNode, folder.id, 0);
+				addNodeInCachedChildren(apolloClient.cache, newNodeWithParent, folder.id, 0);
 				return { newPosition: 0, isLast: true };
 			}
 			// else find the position of the node in the loaded list to check
 			// if the updated node is an ordered or an unordered node
-			const newIndex = addNodeInSortedList(nodes, newNode, nodeSortVar());
-			addNodeInCachedChildren(apolloClient.cache, newNode, folder.id, newIndex);
+			const newIndex = addNodeInSortedList(nodes, newNodeWithParent, nodeSortVar());
+			addNodeInCachedChildren(apolloClient.cache, newNodeWithParent, folder.id, newIndex);
 			return {
 				newPosition: newIndex > -1 ? newIndex : nodes.length,
 				isLast: newIndex === -1 || newIndex === nodes.length

--- a/src/carbonio-files-ui-common/mocks/mockUtils.ts
+++ b/src/carbonio-files-ui-common/mocks/mockUtils.ts
@@ -36,7 +36,7 @@ import {
 	Match,
 	Member
 } from '../types/network';
-import { MakeRequired } from '../types/utils';
+import { MakeRequired, MakeRequiredNonNull } from '../types/utils';
 import { ActionsFactoryNodeType } from '../utils/ActionsFactory';
 import { nodeSortComparator } from '../utils/utils';
 
@@ -104,7 +104,11 @@ export function populateSharePermission(sharePermission?: SharePermission): Shar
 	return sharePermission || SharePermission.ReadAndWrite;
 }
 
-export function populateShare(node: Node, key: number | string, shareTarget?: SharedTarget): Share {
+export function populateShare(
+	node: Node,
+	key: number | string,
+	shareTarget?: SharedTarget
+): MakeRequiredNonNull<Share, 'share_target'> {
 	return {
 		__typename: 'Share',
 		created_at: faker.date.past().getTime(),
@@ -133,7 +137,11 @@ export function populateShares(node: FilesFile | Folder, limit = 1): Share[] {
 	return shares;
 }
 
-function populateNodeFields(type?: NodeType, id?: string, name?: string): Node {
+function populateNodeFields(
+	type?: NodeType,
+	id?: string,
+	name?: string
+): MakeRequiredNonNull<Node, 'owner'> {
 	const types = filter(Object.values(NodeType), (t) => t !== NodeType.Root);
 	const nodeType = type || faker.helpers.arrayElement(types);
 	return {
@@ -307,13 +315,13 @@ export function getVersionFromFile(
 	};
 }
 
-export function populateFile(id?: string, name?: string): FilesFile {
+export function populateFile(id?: string, name?: string): MakeRequiredNonNull<FilesFile, 'owner'> {
 	const mimeType = faker.system.mimeType();
 	const types = filter(
 		Object.values(NodeType),
 		(t) => t !== NodeType.Root && t !== NodeType.Folder
 	);
-	const file: FilesFile = {
+	const file: MakeRequiredNonNull<FilesFile, 'owner'> = {
 		...populateNodeFields(faker.helpers.arrayElement(types), id, name),
 		mime_type: mimeType,
 		size: faker.datatype.number(),

--- a/src/carbonio-files-ui-common/types/common.ts
+++ b/src/carbonio-files-ui-common/types/common.ts
@@ -31,7 +31,7 @@ export type PickIdTypenameNodeType = Pick<Node, 'id' | '__typename'>;
 
 export type GetNodeParentType = {
 	parent?: Maybe<
-		| ({ __typename?: 'File' } & Pick<FilesFile, 'id' | 'name'> & {
+		| ({ __typename?: 'File' } & Pick<FilesFile, 'id'> & {
 					permissions: { __typename?: 'Permissions' } & Pick<
 						Permissions,
 						| 'can_read'
@@ -46,7 +46,7 @@ export type GetNodeParentType = {
 						| 'can_change_share'
 					>;
 				})
-		| ({ __typename?: 'Folder' } & Pick<Folder, 'id' | 'name'> & {
+		| ({ __typename?: 'Folder' } & Pick<Folder, 'id'> & {
 					permissions: { __typename?: 'Permissions' } & Pick<
 						Permissions,
 						| 'can_read'
@@ -85,6 +85,7 @@ export enum Role {
 }
 
 export type NodeListItemType = ChildFragment & {
+	parent?: Pick<NonNullable<Node['parent']>, 'id' | 'permissions'> | null;
 	disabled?: boolean;
 	selectable?: boolean;
 	shares?: Array<Pick<Share, '__typename' | 'created_at'> | null | undefined>;

--- a/src/carbonio-files-ui-common/types/graphql/types.ts
+++ b/src/carbonio-files-ui-common/types/graphql/types.ts
@@ -522,24 +522,6 @@ export type Child_File_Fragment = {
 	rootId?: string | null;
 	owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 	last_editor?: ({ id: string; full_name: string; email: string } & { __typename?: 'User' }) | null;
-	parent?:
-		| ({
-				id: string;
-				name: string;
-				permissions: {
-					can_read: boolean;
-					can_write_file: boolean;
-					can_write_folder: boolean;
-					can_delete: boolean;
-					can_add_version: boolean;
-					can_read_link: boolean;
-					can_change_link: boolean;
-					can_share: boolean;
-					can_read_share: boolean;
-					can_change_share: boolean;
-				} & { __typename?: 'Permissions' };
-		  } & { __typename?: 'File' | 'Folder' })
-		| null;
 	shares: Array<
 		| ({
 				permission: SharePermission;
@@ -575,24 +557,6 @@ export type Child_Folder_Fragment = {
 	rootId?: string | null;
 	owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 	last_editor?: ({ id: string; full_name: string; email: string } & { __typename?: 'User' }) | null;
-	parent?:
-		| ({
-				id: string;
-				name: string;
-				permissions: {
-					can_read: boolean;
-					can_write_file: boolean;
-					can_write_folder: boolean;
-					can_delete: boolean;
-					can_add_version: boolean;
-					can_read_link: boolean;
-					can_change_link: boolean;
-					can_share: boolean;
-					can_read_share: boolean;
-					can_change_share: boolean;
-				} & { __typename?: 'Permissions' };
-		  } & { __typename?: 'File' | 'Folder' })
-		| null;
 	shares: Array<
 		| ({
 				permission: SharePermission;
@@ -621,6 +585,122 @@ export type Child_Folder_Fragment = {
 
 export type ChildFragment = Child_File_Fragment | Child_Folder_Fragment;
 
+export type ChildWithParent_File_Fragment = {
+	updated_at: number;
+	size: number;
+	mime_type: string;
+	extension?: string | null;
+	version: number;
+	id: string;
+	name: string;
+	type: NodeType;
+	flagged: boolean;
+	rootId?: string | null;
+	owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+	last_editor?: ({ id: string; full_name: string; email: string } & { __typename?: 'User' }) | null;
+	shares: Array<
+		| ({
+				permission: SharePermission;
+				created_at: number;
+				share_target?:
+					| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+					| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+					| null;
+				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+		  } & { __typename?: 'Share' })
+		| null
+	>;
+	parent?:
+		| ({
+				id: string;
+				name: string;
+				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+				permissions: {
+					can_read: boolean;
+					can_write_file: boolean;
+					can_write_folder: boolean;
+					can_delete: boolean;
+					can_add_version: boolean;
+					can_read_link: boolean;
+					can_change_link: boolean;
+					can_share: boolean;
+					can_read_share: boolean;
+					can_change_share: boolean;
+				} & { __typename?: 'Permissions' };
+		  } & { __typename?: 'File' | 'Folder' })
+		| null;
+	permissions: {
+		can_read: boolean;
+		can_write_file: boolean;
+		can_write_folder: boolean;
+		can_delete: boolean;
+		can_add_version: boolean;
+		can_read_link: boolean;
+		can_change_link: boolean;
+		can_share: boolean;
+		can_read_share: boolean;
+		can_change_share: boolean;
+	} & { __typename?: 'Permissions' };
+} & { __typename?: 'File' };
+
+export type ChildWithParent_Folder_Fragment = {
+	updated_at: number;
+	id: string;
+	name: string;
+	type: NodeType;
+	flagged: boolean;
+	rootId?: string | null;
+	owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+	last_editor?: ({ id: string; full_name: string; email: string } & { __typename?: 'User' }) | null;
+	shares: Array<
+		| ({
+				permission: SharePermission;
+				created_at: number;
+				share_target?:
+					| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+					| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+					| null;
+				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+		  } & { __typename?: 'Share' })
+		| null
+	>;
+	parent?:
+		| ({
+				id: string;
+				name: string;
+				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+				permissions: {
+					can_read: boolean;
+					can_write_file: boolean;
+					can_write_folder: boolean;
+					can_delete: boolean;
+					can_add_version: boolean;
+					can_read_link: boolean;
+					can_change_link: boolean;
+					can_share: boolean;
+					can_read_share: boolean;
+					can_change_share: boolean;
+				} & { __typename?: 'Permissions' };
+		  } & { __typename?: 'File' | 'Folder' })
+		| null;
+	permissions: {
+		can_read: boolean;
+		can_write_file: boolean;
+		can_write_folder: boolean;
+		can_delete: boolean;
+		can_add_version: boolean;
+		can_read_link: boolean;
+		can_change_link: boolean;
+		can_share: boolean;
+		can_read_share: boolean;
+		can_change_share: boolean;
+	} & { __typename?: 'Permissions' };
+} & { __typename?: 'Folder' };
+
+export type ChildWithParentFragment =
+	| ChildWithParent_File_Fragment
+	| ChildWithParent_Folder_Fragment;
+
 export type CollaborationLinkFragment = {
 	id: string;
 	url: string;
@@ -637,6 +717,46 @@ export type LinkFragment = {
 	created_at: number;
 	node: { id: string } & { __typename?: 'File' | 'Folder' };
 } & { __typename?: 'Link' };
+
+export type NodeParentFragment = {
+	parent?:
+		| ({
+				id: string;
+				name: string;
+				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+				permissions: {
+					can_read: boolean;
+					can_write_file: boolean;
+					can_write_folder: boolean;
+					can_delete: boolean;
+					can_add_version: boolean;
+					can_read_link: boolean;
+					can_change_link: boolean;
+					can_share: boolean;
+					can_read_share: boolean;
+					can_change_share: boolean;
+				} & { __typename?: 'Permissions' };
+		  } & { __typename?: 'File' | 'Folder' })
+		| null;
+} & { __typename?: 'File' | 'Folder' };
+
+export type ParentFragment = {
+	id: string;
+	name: string;
+	owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+	permissions: {
+		can_read: boolean;
+		can_write_file: boolean;
+		can_write_folder: boolean;
+		can_delete: boolean;
+		can_add_version: boolean;
+		can_read_link: boolean;
+		can_change_link: boolean;
+		can_share: boolean;
+		can_read_share: boolean;
+		can_change_share: boolean;
+	} & { __typename?: 'Permissions' };
+} & { __typename?: 'File' | 'Folder' };
 
 export type ParentIdFragment = {
 	parent?: ({ id: string } & { __typename?: 'File' | 'Folder' }) | null;
@@ -706,27 +826,10 @@ export type CopyNodesMutation = {
 				type: NodeType;
 				flagged: boolean;
 				rootId?: string | null;
+				parent?: ({ id: string; name: string } & { __typename?: 'File' | 'Folder' }) | null;
 				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
-					| null;
-				parent?:
-					| ({
-							id: string;
-							name: string;
-							permissions: {
-								can_read: boolean;
-								can_write_file: boolean;
-								can_write_folder: boolean;
-								can_delete: boolean;
-								can_add_version: boolean;
-								can_read_link: boolean;
-								can_change_link: boolean;
-								can_share: boolean;
-								can_read_share: boolean;
-								can_change_share: boolean;
-							} & { __typename?: 'Permissions' };
-					  } & { __typename?: 'File' | 'Folder' })
 					| null;
 				shares: Array<
 					| ({
@@ -760,27 +863,10 @@ export type CopyNodesMutation = {
 				type: NodeType;
 				flagged: boolean;
 				rootId?: string | null;
+				parent?: ({ id: string; name: string } & { __typename?: 'File' | 'Folder' }) | null;
 				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
-					| null;
-				parent?:
-					| ({
-							id: string;
-							name: string;
-							permissions: {
-								can_read: boolean;
-								can_write_file: boolean;
-								can_write_folder: boolean;
-								can_delete: boolean;
-								can_add_version: boolean;
-								can_read_link: boolean;
-								can_change_link: boolean;
-								can_share: boolean;
-								can_read_share: boolean;
-								can_change_share: boolean;
-							} & { __typename?: 'Permissions' };
-					  } & { __typename?: 'File' | 'Folder' })
 					| null;
 				shares: Array<
 					| ({
@@ -844,27 +930,10 @@ export type CreateFolderMutation = {
 				type: NodeType;
 				flagged: boolean;
 				rootId?: string | null;
+				parent?: ({ id: string; name: string } & { __typename?: 'File' | 'Folder' }) | null;
 				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
-					| null;
-				parent?:
-					| ({
-							id: string;
-							name: string;
-							permissions: {
-								can_read: boolean;
-								can_write_file: boolean;
-								can_write_folder: boolean;
-								can_delete: boolean;
-								can_add_version: boolean;
-								can_read_link: boolean;
-								can_change_link: boolean;
-								can_share: boolean;
-								can_read_share: boolean;
-								can_change_share: boolean;
-							} & { __typename?: 'Permissions' };
-					  } & { __typename?: 'File' | 'Folder' })
 					| null;
 				shares: Array<
 					| ({
@@ -898,27 +967,10 @@ export type CreateFolderMutation = {
 				type: NodeType;
 				flagged: boolean;
 				rootId?: string | null;
+				parent?: ({ id: string; name: string } & { __typename?: 'File' | 'Folder' }) | null;
 				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
-					| null;
-				parent?:
-					| ({
-							id: string;
-							name: string;
-							permissions: {
-								can_read: boolean;
-								can_write_file: boolean;
-								can_write_folder: boolean;
-								can_delete: boolean;
-								can_add_version: boolean;
-								can_read_link: boolean;
-								can_change_link: boolean;
-								can_share: boolean;
-								can_read_share: boolean;
-								can_change_share: boolean;
-							} & { __typename?: 'Permissions' };
-					  } & { __typename?: 'File' | 'Folder' })
 					| null;
 				shares: Array<
 					| ({
@@ -1101,9 +1153,12 @@ export type UpdateNodeMutationVariables = Exact<{
 }>;
 
 export type UpdateNodeMutation = {
-	updateNode: { id: string; name: string; description: string } & {
-		__typename?: 'File' | 'Folder';
-	};
+	updateNode: {
+		id: string;
+		name: string;
+		description: string;
+		parent?: ({ id: string } & { __typename?: 'File' | 'Folder' }) | null;
+	} & { __typename?: 'File' | 'Folder' };
 } & { __typename?: 'Mutation' };
 
 export type UpdateNodeDescriptionMutationVariables = Exact<{
@@ -1171,10 +1226,25 @@ export type FindNodesQuery = {
 							last_editor?:
 								| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 								| null;
+							shares: Array<
+								| ({
+										permission: SharePermission;
+										created_at: number;
+										share_target?:
+											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+											| null;
+										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+								  } & { __typename?: 'Share' })
+								| null
+							>;
 							parent?:
 								| ({
 										id: string;
 										name: string;
+										owner: { id: string; full_name: string; email: string } & {
+											__typename?: 'User';
+										};
 										permissions: {
 											can_read: boolean;
 											can_write_file: boolean;
@@ -1189,18 +1259,6 @@ export type FindNodesQuery = {
 										} & { __typename?: 'Permissions' };
 								  } & { __typename?: 'File' | 'Folder' })
 								| null;
-							shares: Array<
-								| ({
-										permission: SharePermission;
-										created_at: number;
-										share_target?:
-											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
-											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
-											| null;
-										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
-								  } & { __typename?: 'Share' })
-								| null
-							>;
 							permissions: {
 								can_read: boolean;
 								can_write_file: boolean;
@@ -1225,10 +1283,25 @@ export type FindNodesQuery = {
 							last_editor?:
 								| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 								| null;
+							shares: Array<
+								| ({
+										permission: SharePermission;
+										created_at: number;
+										share_target?:
+											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+											| null;
+										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+								  } & { __typename?: 'Share' })
+								| null
+							>;
 							parent?:
 								| ({
 										id: string;
 										name: string;
+										owner: { id: string; full_name: string; email: string } & {
+											__typename?: 'User';
+										};
 										permissions: {
 											can_read: boolean;
 											can_write_file: boolean;
@@ -1243,18 +1316,6 @@ export type FindNodesQuery = {
 										} & { __typename?: 'Permissions' };
 								  } & { __typename?: 'File' | 'Folder' })
 								| null;
-							shares: Array<
-								| ({
-										permission: SharePermission;
-										created_at: number;
-										share_target?:
-											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
-											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
-											| null;
-										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
-								  } & { __typename?: 'Share' })
-								| null
-							>;
 							permissions: {
 								can_read: boolean;
 								can_write_file: boolean;
@@ -1367,10 +1428,23 @@ export type GetChildQuery = {
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 					| null;
+				shares: Array<
+					| ({
+							permission: SharePermission;
+							created_at: number;
+							share_target?:
+								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+								| null;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+					  } & { __typename?: 'Share' })
+					| null
+				>;
 				parent?:
 					| ({
 							id: string;
 							name: string;
+							owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 							permissions: {
 								can_read: boolean;
 								can_write_file: boolean;
@@ -1385,18 +1459,6 @@ export type GetChildQuery = {
 							} & { __typename?: 'Permissions' };
 					  } & { __typename?: 'File' | 'Folder' })
 					| null;
-				shares: Array<
-					| ({
-							permission: SharePermission;
-							created_at: number;
-							share_target?:
-								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
-								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
-								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
-					  } & { __typename?: 'Share' })
-					| null
-				>;
 				permissions: {
 					can_read: boolean;
 					can_write_file: boolean;
@@ -1421,10 +1483,23 @@ export type GetChildQuery = {
 				last_editor?:
 					| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 					| null;
+				shares: Array<
+					| ({
+							permission: SharePermission;
+							created_at: number;
+							share_target?:
+								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
+								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
+								| null;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
+					  } & { __typename?: 'Share' })
+					| null
+				>;
 				parent?:
 					| ({
 							id: string;
 							name: string;
+							owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
 							permissions: {
 								can_read: boolean;
 								can_write_file: boolean;
@@ -1439,18 +1514,6 @@ export type GetChildQuery = {
 							} & { __typename?: 'Permissions' };
 					  } & { __typename?: 'File' | 'Folder' })
 					| null;
-				shares: Array<
-					| ({
-							permission: SharePermission;
-							created_at: number;
-							share_target?:
-								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
-								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
-								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
-					  } & { __typename?: 'Share' })
-					| null
-				>;
 				permissions: {
 					can_read: boolean;
 					can_write_file: boolean;
@@ -1477,7 +1540,23 @@ export type GetChildrenQueryVariables = Exact<{
 
 export type GetChildrenQuery = {
 	getNode?:
-		| ({ id: string; name: string } & { __typename?: 'File' })
+		| ({
+				id: string;
+				name: string;
+				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+				permissions: {
+					can_read: boolean;
+					can_write_file: boolean;
+					can_write_folder: boolean;
+					can_delete: boolean;
+					can_add_version: boolean;
+					can_read_link: boolean;
+					can_change_link: boolean;
+					can_share: boolean;
+					can_read_share: boolean;
+					can_change_share: boolean;
+				} & { __typename?: 'Permissions' };
+		  } & { __typename?: 'File' })
 		| ({
 				id: string;
 				name: string;
@@ -1499,24 +1578,6 @@ export type GetChildrenQuery = {
 								last_editor?:
 									| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 									| null;
-								parent?:
-									| ({
-											id: string;
-											name: string;
-											permissions: {
-												can_read: boolean;
-												can_write_file: boolean;
-												can_write_folder: boolean;
-												can_delete: boolean;
-												can_add_version: boolean;
-												can_read_link: boolean;
-												can_change_link: boolean;
-												can_share: boolean;
-												can_read_share: boolean;
-												can_change_share: boolean;
-											} & { __typename?: 'Permissions' };
-									  } & { __typename?: 'File' | 'Folder' })
-									| null;
 								shares: Array<
 									| ({
 											permission: SharePermission;
@@ -1531,6 +1592,27 @@ export type GetChildrenQuery = {
 									  } & { __typename?: 'Share' })
 									| null
 								>;
+								parent?:
+									| ({
+											id: string;
+											name: string;
+											owner: { id: string; full_name: string; email: string } & {
+												__typename?: 'User';
+											};
+											permissions: {
+												can_read: boolean;
+												can_write_file: boolean;
+												can_write_folder: boolean;
+												can_delete: boolean;
+												can_add_version: boolean;
+												can_read_link: boolean;
+												can_change_link: boolean;
+												can_share: boolean;
+												can_read_share: boolean;
+												can_change_share: boolean;
+											} & { __typename?: 'Permissions' };
+									  } & { __typename?: 'File' | 'Folder' })
+									| null;
 								permissions: {
 									can_read: boolean;
 									can_write_file: boolean;
@@ -1555,24 +1637,6 @@ export type GetChildrenQuery = {
 								last_editor?:
 									| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 									| null;
-								parent?:
-									| ({
-											id: string;
-											name: string;
-											permissions: {
-												can_read: boolean;
-												can_write_file: boolean;
-												can_write_folder: boolean;
-												can_delete: boolean;
-												can_add_version: boolean;
-												can_read_link: boolean;
-												can_change_link: boolean;
-												can_share: boolean;
-												can_read_share: boolean;
-												can_change_share: boolean;
-											} & { __typename?: 'Permissions' };
-									  } & { __typename?: 'File' | 'Folder' })
-									| null;
 								shares: Array<
 									| ({
 											permission: SharePermission;
@@ -1587,6 +1651,27 @@ export type GetChildrenQuery = {
 									  } & { __typename?: 'Share' })
 									| null
 								>;
+								parent?:
+									| ({
+											id: string;
+											name: string;
+											owner: { id: string; full_name: string; email: string } & {
+												__typename?: 'User';
+											};
+											permissions: {
+												can_read: boolean;
+												can_write_file: boolean;
+												can_write_folder: boolean;
+												can_delete: boolean;
+												can_add_version: boolean;
+												can_read_link: boolean;
+												can_change_link: boolean;
+												can_share: boolean;
+												can_read_share: boolean;
+												can_change_share: boolean;
+											} & { __typename?: 'Permissions' };
+									  } & { __typename?: 'File' | 'Folder' })
+									| null;
 								permissions: {
 									can_read: boolean;
 									can_write_file: boolean;
@@ -1603,6 +1688,19 @@ export type GetChildrenQuery = {
 						| null
 					>;
 				} & { __typename?: 'NodePage' };
+				owner: { id: string; full_name: string; email: string } & { __typename?: 'User' };
+				permissions: {
+					can_read: boolean;
+					can_write_file: boolean;
+					can_write_folder: boolean;
+					can_delete: boolean;
+					can_add_version: boolean;
+					can_read_link: boolean;
+					can_change_link: boolean;
+					can_share: boolean;
+					can_read_share: boolean;
+					can_change_share: boolean;
+				} & { __typename?: 'Permissions' };
 		  } & { __typename?: 'Folder' })
 		| null;
 } & { __typename?: 'Query' };
@@ -1713,24 +1811,6 @@ export type GetNodeQuery = {
 								last_editor?:
 									| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 									| null;
-								parent?:
-									| ({
-											id: string;
-											name: string;
-											permissions: {
-												can_read: boolean;
-												can_write_file: boolean;
-												can_write_folder: boolean;
-												can_delete: boolean;
-												can_add_version: boolean;
-												can_read_link: boolean;
-												can_change_link: boolean;
-												can_share: boolean;
-												can_read_share: boolean;
-												can_change_share: boolean;
-											} & { __typename?: 'Permissions' };
-									  } & { __typename?: 'File' | 'Folder' })
-									| null;
 								shares: Array<
 									| ({
 											permission: SharePermission;
@@ -1745,6 +1825,27 @@ export type GetNodeQuery = {
 									  } & { __typename?: 'Share' })
 									| null
 								>;
+								parent?:
+									| ({
+											id: string;
+											name: string;
+											owner: { id: string; full_name: string; email: string } & {
+												__typename?: 'User';
+											};
+											permissions: {
+												can_read: boolean;
+												can_write_file: boolean;
+												can_write_folder: boolean;
+												can_delete: boolean;
+												can_add_version: boolean;
+												can_read_link: boolean;
+												can_change_link: boolean;
+												can_share: boolean;
+												can_read_share: boolean;
+												can_change_share: boolean;
+											} & { __typename?: 'Permissions' };
+									  } & { __typename?: 'File' | 'Folder' })
+									| null;
 								permissions: {
 									can_read: boolean;
 									can_write_file: boolean;
@@ -1769,24 +1870,6 @@ export type GetNodeQuery = {
 								last_editor?:
 									| ({ id: string; full_name: string; email: string } & { __typename?: 'User' })
 									| null;
-								parent?:
-									| ({
-											id: string;
-											name: string;
-											permissions: {
-												can_read: boolean;
-												can_write_file: boolean;
-												can_write_folder: boolean;
-												can_delete: boolean;
-												can_add_version: boolean;
-												can_read_link: boolean;
-												can_change_link: boolean;
-												can_share: boolean;
-												can_read_share: boolean;
-												can_change_share: boolean;
-											} & { __typename?: 'Permissions' };
-									  } & { __typename?: 'File' | 'Folder' })
-									| null;
 								shares: Array<
 									| ({
 											permission: SharePermission;
@@ -1801,6 +1884,27 @@ export type GetNodeQuery = {
 									  } & { __typename?: 'Share' })
 									| null
 								>;
+								parent?:
+									| ({
+											id: string;
+											name: string;
+											owner: { id: string; full_name: string; email: string } & {
+												__typename?: 'User';
+											};
+											permissions: {
+												can_read: boolean;
+												can_write_file: boolean;
+												can_write_folder: boolean;
+												can_delete: boolean;
+												can_add_version: boolean;
+												can_read_link: boolean;
+												can_change_link: boolean;
+												can_share: boolean;
+												can_read_share: boolean;
+												can_change_share: boolean;
+											} & { __typename?: 'Permissions' };
+									  } & { __typename?: 'File' | 'Folder' })
+									| null;
 								permissions: {
 									can_read: boolean;
 									can_write_file: boolean;
@@ -2440,7 +2544,35 @@ export const BaseNodeFragmentDoc = {
 				]
 			}
 		},
-		...PermissionsFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<BaseNodeFragment, unknown>;
 export const ShareFragmentDoc = {
@@ -2544,13 +2676,462 @@ export const ChildFragmentDoc = {
 					},
 					{
 						kind: 'Field',
-						name: { kind: 'Name', value: 'parent' },
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
 						selectionSet: {
 							kind: 'SelectionSet',
 							selections: [
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
-								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<ChildFragment, unknown>;
+export const ParentFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<ParentFragment, unknown>;
+export const NodeParentFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		}
+	]
+} as unknown as DocumentNode<NodeParentFragment, unknown>;
+export const ChildWithParentFragmentDoc = {
+	kind: 'Document',
+	definitions: [
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ChildWithParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'NodeParent' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
 							]
 						}
 					},
@@ -2572,11 +3153,26 @@ export const ChildFragmentDoc = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions,
-		...PermissionsFragmentDoc.definitions,
-		...ShareFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		}
 	]
-} as unknown as DocumentNode<ChildFragment, unknown>;
+} as unknown as DocumentNode<ChildWithParentFragment, unknown>;
 export const CollaborationLinkFragmentDoc = {
 	kind: 'Document',
 	definitions: [
@@ -2811,13 +3407,192 @@ export const CopyNodesDocument = {
 						],
 						selectionSet: {
 							kind: 'SelectionSet',
-							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }]
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'parent' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
 						}
 					}
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CopyNodesMutation, CopyNodesMutationVariables>;
 export const CreateCollaborationLinkDocument = {
@@ -2873,7 +3648,28 @@ export const CreateCollaborationLinkDocument = {
 				]
 			}
 		},
-		...CollaborationLinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollaborationLink' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'CollaborationLink' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	CreateCollaborationLinkMutation,
@@ -2930,13 +3726,192 @@ export const CreateFolderDocument = {
 						],
 						selectionSet: {
 							kind: 'SelectionSet',
-							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }]
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'parent' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
 						}
 					}
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CreateFolderMutation, CreateFolderMutationVariables>;
 export const CreateLinkDocument = {
@@ -2997,7 +3972,29 @@ export const CreateLinkDocument = {
 				]
 			}
 		},
-		...LinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Link' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Link' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'expires_at' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CreateLinkMutation, CreateLinkMutationVariables>;
 export const CreateShareDocument = {
@@ -3749,7 +4746,15 @@ export const UpdateNodeDocument = {
 							selections: [
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
 								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'description' } }
+								{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'parent' },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+									}
+								}
 							]
 						}
 					}
@@ -4083,7 +5088,9 @@ export const FindNodesDocument = {
 									name: { kind: 'Name', value: 'nodes' },
 									selectionSet: {
 										kind: 'SelectionSet',
-										selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }]
+										selections: [
+											{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'ChildWithParent' } }
+										]
 									}
 								},
 								{ kind: 'Field', name: { kind: 'Name', value: 'page_token' } }
@@ -4093,7 +5100,228 @@ export const FindNodesDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ChildWithParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'NodeParent' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<FindNodesQuery, FindNodesQueryVariables>;
 export const GetAccountByEmailDocument = {
@@ -4267,7 +5495,64 @@ export const GetBaseNodeDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetBaseNodeQuery, GetBaseNodeQueryVariables>;
 export const GetChildDocument = {
@@ -4308,13 +5593,236 @@ export const GetChildDocument = {
 						],
 						selectionSet: {
 							kind: 'SelectionSet',
-							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }]
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'ChildWithParent' } }
+							]
 						}
 					}
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'ChildWithParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'NodeParent' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetChildQuery, GetChildQueryVariables>;
 export const GetChildrenDocument = {
@@ -4377,8 +5885,7 @@ export const GetChildrenDocument = {
 						selectionSet: {
 							kind: 'SelectionSet',
 							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } },
 								{
 									kind: 'InlineFragment',
 									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Folder' } },
@@ -4417,7 +5924,17 @@ export const GetChildrenDocument = {
 															selectionSet: {
 																kind: 'SelectionSet',
 																selections: [
-																	{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }
+																	{
+																		kind: 'FragmentSpread',
+																		name: { kind: 'Name', value: 'Child' }
+																	},
+																	{
+																		kind: 'FragmentSpread',
+																		name: { kind: 'Name', value: 'NodeParent' },
+																		directives: [
+																			{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }
+																		]
+																	}
 																]
 															}
 														},
@@ -4434,7 +5951,216 @@ export const GetChildrenDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetChildrenQuery, GetChildrenQueryVariables>;
 export const GetConfigsDocument = {
@@ -4656,7 +6382,17 @@ export const GetNodeDocument = {
 															selectionSet: {
 																kind: 'SelectionSet',
 																selections: [
-																	{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Child' } }
+																	{
+																		kind: 'FragmentSpread',
+																		name: { kind: 'Name', value: 'Child' }
+																	},
+																	{
+																		kind: 'FragmentSpread',
+																		name: { kind: 'Name', value: 'NodeParent' },
+																		directives: [
+																			{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }
+																		]
+																	}
 																]
 															}
 														},
@@ -4673,10 +6409,216 @@ export const GetNodeDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions,
-		...PermissionsFragmentDoc.definitions,
-		...ShareFragmentDoc.definitions,
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Parent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'NodeParent' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Parent' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetNodeQuery, GetNodeQueryVariables>;
 export const GetNodeCollaborationLinksDocument = {
@@ -4729,7 +6671,28 @@ export const GetNodeCollaborationLinksDocument = {
 				]
 			}
 		},
-		...CollaborationLinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollaborationLink' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'CollaborationLink' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	GetNodeCollaborationLinksQuery,
@@ -4783,7 +6746,29 @@ export const GetNodeLinksDocument = {
 				]
 			}
 		},
-		...LinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Link' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Link' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'expires_at' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetNodeLinksQuery, GetNodeLinksQueryVariables>;
 export const GetParentDocument = {
@@ -4846,7 +6831,64 @@ export const GetParentDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetParentQuery, GetParentQueryVariables>;
 export const GetPathDocument = {
@@ -4887,7 +6929,64 @@ export const GetPathDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetPathQuery, GetPathQueryVariables>;
 export const GetPermissionsDocument = {
@@ -4931,7 +7030,35 @@ export const GetPermissionsDocument = {
 				]
 			}
 		},
-		...PermissionsFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetPermissionsQuery, GetPermissionsQueryVariables>;
 export const GetRootsListDocument = {
@@ -5049,7 +7176,64 @@ export const GetSharesDocument = {
 				]
 			}
 		},
-		...ShareFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetSharesQuery, GetSharesQueryVariables>;
 export const GetUploadItemDocument = {

--- a/src/carbonio-files-ui-common/types/utils.ts
+++ b/src/carbonio-files-ui-common/types/utils.ts
@@ -11,7 +11,11 @@ export type OneOrMany<T> = T | T[];
 export type ArrayOneOrMore<T> = [T] & T[];
 
 export type DeepPick<T, K extends keyof T, KK extends keyof NonNullable<T[K]>> = {
-	[P in K]: T[P] extends Record<KK, unknown> ? Pick<T[P], KK> : T[P];
+	[P in K]: T[P] extends Record<KK, unknown>
+		? T[P] extends null | undefined
+			? Pick<NonNullable<T[P]>, KK> | null | undefined
+			: Pick<NonNullable<T[P]>, KK>
+		: T[P];
 };
 
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: T[SubKey] };
@@ -33,6 +37,8 @@ export type NonNullableList<T extends Array<unknown>> = Array<NonNullable<Unwrap
 export type NonNullableListItem<T extends Array<unknown>> = Unwrap<NonNullableList<T>>;
 
 export type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+export type MakeRequiredNonNull<T, K extends keyof T> = T & { [KK in K]-?: NonNullable<T[KK]> };
 
 export type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
 	? `${T}${Capitalize<SnakeToCamelCase<U>>}`

--- a/src/carbonio-files-ui-common/utils/ActionsFactory.ts
+++ b/src/carbonio-files-ui-common/utils/ActionsFactory.ts
@@ -167,7 +167,7 @@ export function canCreateFolder(
 	return destinationNode.permissions.can_write_folder;
 }
 
-export function canUploadFile(
+export function canCreateFile(
 	destinationNode: Pick<ActionsFactoryNodeType, '__typename' | 'permissions'>
 ): boolean {
 	if (isFile(destinationNode)) {
@@ -179,16 +179,10 @@ export function canUploadFile(
 	return destinationNode.permissions.can_write_file;
 }
 
-export function canCreateFile(
+export function canUploadFile(
 	destinationNode: Pick<ActionsFactoryNodeType, '__typename' | 'permissions'>
 ): boolean {
-	if (isFile(destinationNode)) {
-		throw Error('destinationNode must be a Folder');
-	}
-	if (!isBoolean(destinationNode.permissions.can_write_file)) {
-		throw Error('can_write_file not defined');
-	}
-	return destinationNode.permissions.can_write_file;
+	return canCreateFile(destinationNode);
 }
 
 export function canBeWriteNodeDestination(
@@ -309,13 +303,13 @@ export function canMove(
 				!!node.parent &&
 				// TODO: REMOVE CHECK ON ROOT WHEN BE WILL NOT RETURN LOCAL_ROOT AS PARENT FOR SHARED NODES
 				(node.parent.id !== ROOTS.LOCAL_ROOT || node.owner.id === loggedUserId) &&
-				!!node.parent.permissions.can_write_file &&
+				node.parent.permissions.can_write_file &&
 				node.rootId !== ROOTS.TRASH;
 		} else if (isFolder(node)) {
 			if (!isBoolean(node.permissions.can_write_folder)) {
 				throw Error('can_write_folder not defined');
 			}
-			// a folder can be moved if it has can_write_folder permission and it has a parent which has can_write_folder permission
+			// a folder can be moved if it has can_write_folder permission, and it has a parent which has can_write_folder permission
 			canMoveResult =
 				node.permissions.can_write_folder &&
 				!!node.parent &&

--- a/src/carbonio-files-ui-common/utils/uploadUtils.ts
+++ b/src/carbonio-files-ui-common/utils/uploadUtils.ts
@@ -314,7 +314,7 @@ function loadItemAsChild(
 				query: GET_CHILD,
 				fetchPolicy: 'no-cache',
 				variables: {
-					node_id: nodeId as string
+					node_id: nodeId
 				}
 			})
 			.then((result) => {

--- a/src/carbonio-files-ui-common/utils/utils.ts
+++ b/src/carbonio-files-ui-common/utils/utils.ts
@@ -57,6 +57,7 @@ import {
 	NodeType,
 	SharePermission
 } from '../types/graphql/types';
+import { MakeRequiredNonNull } from '../types/utils';
 
 /**
  * Format a size in byte as human-readable
@@ -846,12 +847,12 @@ export function cssCalcBuilder(
 
 export function isFile(
 	node: ({ __typename?: string } & Record<string, unknown>) | null | undefined
-): node is File {
+): node is File & MakeRequiredNonNull<File, '__typename'> {
 	return node?.__typename === 'File';
 }
 
 export function isFolder(
 	node: ({ __typename?: string } & Record<string, unknown>) | null | undefined
-): node is Folder {
+): node is Folder & MakeRequiredNonNull<Folder, '__typename'> {
 	return node?.__typename === 'Folder';
 }

--- a/src/carbonio-files-ui-common/views/FolderView.test.tsx
+++ b/src/carbonio-files-ui-common/views/FolderView.test.tsx
@@ -14,7 +14,6 @@ import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import GET_CHILD from '../graphql/queries/getChild.graphql';
 import GET_CHILDREN from '../graphql/queries/getChildren.graphql';
 import GET_NODE from '../graphql/queries/getNode.graphql';
-import GET_PATH from '../graphql/queries/getPath.graphql';
 import GET_PERMISSIONS from '../graphql/queries/getPermissions.graphql';
 import { populateFolder, populateNode, populateParents } from '../mocks/mockUtils';
 import { Node } from '../types/common';
@@ -27,8 +26,6 @@ import {
 	GetNodeQueryVariables,
 	GetParentQuery,
 	GetParentQueryVariables,
-	GetPathQuery,
-	GetPathQueryVariables,
 	GetPermissionsQuery,
 	GetPermissionsQueryVariables
 } from '../types/graphql/types';
@@ -37,7 +34,11 @@ import {
 	getNodeVariables,
 	mockGetChild,
 	mockGetChildren,
-	mockGetParent
+	mockGetNode,
+	mockGetParent,
+	mockGetPath,
+	mockGetPermissions,
+	mockMoveNodes
 } from '../utils/mockUtils';
 import { buildBreadCrumbRegExp, moveNode, setup } from '../utils/testUtils';
 
@@ -155,8 +156,8 @@ describe('Folder View', () => {
 			expect(map(mockedCreateOptions, (createOption) => createOption.action({}))).toEqual(
 				expect.arrayContaining([expect.objectContaining({ id: 'create-folder', disabled: false })])
 			);
+			expect.assertions(1);
 		});
-		expect.assertions(1);
 	});
 
 	describe('Displayer', () => {
@@ -221,64 +222,26 @@ describe('Folder View', () => {
 			currentFolder.children.nodes.push(node);
 			const path = [...parentPath, node];
 
-			// prepare cache so that apollo client read data from the cache
-			global.apolloClient.writeQuery<GetChildrenQuery, GetChildrenQueryVariables>({
-				query: GET_CHILDREN,
-				variables: getChildrenVariables(currentFolder.id),
-				data: {
-					getNode: currentFolder
-				}
-			});
-			global.apolloClient.writeQuery<GetChildQuery, GetChildQueryVariables>({
-				query: GET_CHILD,
-				variables: {
-					node_id: currentFolder.id,
-					shares_limit: 1
-				},
-				data: {
-					getNode: currentFolder
-				}
-			});
-			global.apolloClient.writeQuery<GetNodeQuery, GetNodeQueryVariables>({
-				query: GET_NODE,
-				variables: getNodeVariables(node.id),
-				data: {
-					getNode: node
-				}
-			});
-			global.apolloClient.writeQuery<GetPathQuery, GetPathQueryVariables>({
-				query: GET_PATH,
-				variables: { node_id: node.id },
-				data: {
-					getPath: path
-				}
-			});
-			const getNodeParentMockedQuery = mockGetParent({ node_id: node.id }, node);
-			global.apolloClient.writeQuery<GetParentQuery, GetParentQueryVariables>({
-				...getNodeParentMockedQuery.request,
-				data: {
-					getNode: node
-				}
-			});
-			const getCurrentFolderParentMockedQuery = mockGetParent(
-				{ node_id: currentFolder.id },
-				currentFolder
-			);
-			global.apolloClient.writeQuery<GetParentQuery, GetParentQueryVariables>({
-				...getCurrentFolderParentMockedQuery.request,
-				data: {
-					getNode: currentFolder
-				}
-			});
-			const { findByTextWithMarkup, user } = setup(<FolderView />, {
-				initialRouterEntries: [`/?folder=${currentFolder.id}&node=${node.id}`]
+			const mocks = [
+				mockGetChildren(getChildrenVariables(currentFolder.id), currentFolder),
+				mockGetPermissions({ node_id: currentFolder.id }, currentFolder),
+				mockGetChild({ node_id: currentFolder.id }, currentFolder),
+				mockGetNode(getNodeVariables(node.id), node),
+				mockGetPath({ node_id: node.id }, path),
+				mockGetPath({ node_id: currentFolder.id }, parentPath),
+				mockGetParent({ node_id: node.id }, node),
+				mockGetParent({ node_id: currentFolder.id }, currentFolder),
+				mockMoveNodes({ destination_id: destinationFolder.id, node_ids: [node.id] }, [
+					{ ...node, parent: destinationFolder }
+				])
+			];
+			const { user } = setup(<FolderView />, {
+				initialRouterEntries: [`/?folder=${currentFolder.id}&node=${node.id}`],
+				mocks
 			});
 			const displayer = await screen.findByTestId('displayer');
+			await screen.findAllByText(node.name);
 			expect(within(displayer).getAllByText(node.name)).toHaveLength(2);
-			const breadcrumbItem = await findByTextWithMarkup(
-				buildBreadCrumbRegExp(...map(path, (parent) => parent.name))
-			);
-			expect(breadcrumbItem).toBeVisible();
 			// right click to open contextual menu
 			const nodeToMoveItem = within(screen.getByTestId(`list-${currentFolder.id}`)).getByText(
 				node.name
@@ -404,7 +367,7 @@ describe('Folder View', () => {
 					expect.objectContaining({ id: 'create-docs-presentation', disabled: false })
 				])
 			);
+			expect.assertions(1);
 		});
-		expect.assertions(1);
 	});
 });


### PR DESCRIPTION
Parent node is already available in cache when requesting children. Avoid asking this field from network, read the cached data instead.

refs: FILES-477