### PR TITLE
perf: read node from cache in shares field

### DIFF
--- a/src/carbonio-files-ui-common/apollo/typePolicies/Node.ts
+++ b/src/carbonio-files-ui-common/apollo/typePolicies/Node.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { FieldFunctionOptions, TypePolicy } from '@apollo/client';
+import { map } from 'lodash';
 
 import { ShareCachedObject, SharesCachedObject } from '../../types/apollo';
+import { Node } from '../../types/common';
 import { NodeSharesArgs } from '../../types/graphql/types';
 
 export const nodeTypePolicies: TypePolicy = {
@@ -14,22 +16,35 @@ export const nodeTypePolicies: TypePolicy = {
 		shares: {
 			keyArgs: false,
 			merge(
-				existing: ShareCachedObject[],
+				existing: SharesCachedObject,
 				incoming: ShareCachedObject[],
 				{ args }: FieldFunctionOptions<Partial<NodeSharesArgs>>
 			): SharesCachedObject {
 				if (args?.cursor) {
-					const newExisting = existing || [];
+					const newExisting = existing.shares || [];
 					return {
 						args,
 						shares: [...newExisting, ...incoming]
 					};
 				}
+				// return the already cached data when:
+				// a previous query requested a greater number of shares (cached limit is greater than args limit)
+				// or
+				// cached shares number is lower than the previous query limit
+				// (so even requesting a greater limit, the returned share will be the same of the already cached)
+				if (
+					existing?.args?.limit !== undefined &&
+					(args?.limit === undefined ||
+						existing.args.limit >= args.limit ||
+						existing.shares.length < existing.args.limit)
+				) {
+					return existing;
+				}
 				return { args, shares: [...incoming] };
 			},
 			read(
 				existing: SharesCachedObject,
-				{ args }: FieldFunctionOptions<Partial<NodeSharesArgs>>
+				{ args, readField, toReference }: FieldFunctionOptions<Partial<NodeSharesArgs>>
 			): ShareCachedObject[] | undefined {
 				// return the already cached data when:
 				// cached data is missing
@@ -41,14 +56,23 @@ export const nodeTypePolicies: TypePolicy = {
 				// cached shares number is lower than the previous query limit
 				// (so even requesting a greater limit, the returned share will be the same of the already cached)
 				if (
-					!existing?.args?.limit ||
-					!args?.limit ||
-					existing.args.limit >= args.limit ||
-					existing.shares.length < existing.args.limit
+					existing &&
+					(existing?.args?.limit === undefined ||
+						args?.limit === undefined ||
+						existing.args.limit >= args.limit ||
+						existing.shares.length < existing.args.limit)
 				) {
-					return existing?.shares;
+					const nodeId = readField<string>('id');
+					const nodeTypeName = readField<Node['__typename']>('__typename');
+					return map(existing.shares, (share) => ({
+						...share,
+						node: toReference({ __typename: nodeTypeName, id: nodeId })
+					}));
 				}
-				// otherwise, if a query is requesting a number of shares grater then the cached data,
+				// otherwise, if
+				// there is no cached data
+				// or
+				// a query is requesting a number of shares greater than the cached data,
 				// return undefined to force the network request
 				return undefined;
 			}

--- a/src/carbonio-files-ui-common/graphql/fragments/child.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/child.graphql
@@ -26,5 +26,9 @@ fragment Child on Node {
 	}
 	shares(limit: $shares_limit) {
 		...Share
+		node @client {
+			id
+			type
+		}
 	}
 }

--- a/src/carbonio-files-ui-common/graphql/fragments/share.graphql
+++ b/src/carbonio-files-ui-common/graphql/fragments/share.graphql
@@ -12,8 +12,4 @@ fragment Share on Share {
         }
     }
     created_at
-    node {
-        id
-        type
-    }
 }

--- a/src/carbonio-files-ui-common/graphql/queries/getNode.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/getNode.graphql
@@ -35,6 +35,10 @@ query getNode($node_id: ID!, $children_limit: Int!, $page_token: String, $sort: 
 		}
 		shares(limit: $shares_limit, cursor: $shares_cursor, sorts: $shares_sorts) {
 			...Share
+			node @client {
+				id
+				type
+			}
 		}
 		... on Folder {
 			children(limit: $children_limit, page_token: $page_token, sort: $sort) {

--- a/src/carbonio-files-ui-common/graphql/queries/getShares.graphql
+++ b/src/carbonio-files-ui-common/graphql/queries/getShares.graphql
@@ -6,9 +6,16 @@
 
 query getShares($node_id: ID!, $shares_limit: Int!, $shares_cursor: String, $shares_sorts: [ShareSort!]) {
 	getNode(node_id: $node_id) {
+		# require all fields specified inside share.node @client directive, so that the cache can add those field
+		# at runtime without the need to ask them from the network
 		id
+		type
 		shares(limit: $shares_limit, cursor: $shares_cursor, sorts: $shares_sorts) {
 			...Share
+			node @client {
+				id
+				type
+			}
 		}
 	}
 }

--- a/src/carbonio-files-ui-common/hooks/graphql/mutations/useCopyNodesMutation.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/mutations/useCopyNodesMutation.ts
@@ -14,6 +14,7 @@ import { useParams } from 'react-router-dom';
 
 import { useNavigation } from '../../../../hooks/useNavigation';
 import { nodeSortVar } from '../../../apollo/nodeSortVar';
+import { SHARES_LOAD_LIMIT } from '../../../constants';
 import COPY_NODES from '../../../graphql/mutations/copyNodes.graphql';
 import GET_CHILDREN from '../../../graphql/queries/getChildren.graphql';
 import { PickIdNodeType } from '../../../types/common';
@@ -82,7 +83,8 @@ export function useCopyNodesMutation(): { copyNodes: CopyNodesType; loading: boo
 			return copyNodesMutation({
 				variables: {
 					node_ids: nodesIds,
-					destination_id: destinationFolder.id
+					destination_id: destinationFolder.id,
+					shares_limit: SHARES_LOAD_LIMIT
 				},
 				update(cache, { data: result }) {
 					const currentFolderId = folderId || rootId;

--- a/src/carbonio-files-ui-common/hooks/graphql/mutations/useCreateFolderMutation.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/mutations/useCreateFolderMutation.ts
@@ -9,6 +9,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, MutationHookOptions, MutationResult, useMutation } from '@apollo/client';
 
+import { SHARES_LOAD_LIMIT } from '../../../constants';
 import CREATE_FOLDER from '../../../graphql/mutations/createFolder.graphql';
 import {
 	CreateFolderMutation,
@@ -48,7 +49,8 @@ export function useCreateFolderMutation(
 			return createFolderMutation({
 				variables: {
 					destination_id: parentFolder.id,
-					name
+					name,
+					shares_limit: SHARES_LOAD_LIMIT
 				},
 				// after the mutation returns a response, check if next neighbor is already loaded.
 				// If so, write the folder in cache,

--- a/src/carbonio-files-ui-common/hooks/graphql/queries/useFindNodesQuery.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/queries/useFindNodesQuery.ts
@@ -9,7 +9,7 @@ import { useCallback } from 'react';
 import { ApolloQueryResult, QueryResult, useQuery } from '@apollo/client';
 import { isEqual } from 'lodash';
 
-import { NODES_LOAD_LIMIT } from '../../../constants';
+import { NODES_LOAD_LIMIT, SHARES_LOAD_LIMIT } from '../../../constants';
 import FIND_NODES from '../../../graphql/queries/findNodes.graphql';
 import { SearchParams } from '../../../types/common';
 import { FindNodesQuery, FindNodesQueryVariables, NodeSort } from '../../../types/graphql/types';
@@ -56,7 +56,8 @@ export function useFindNodesQuery({
 				sort,
 				direct_share: directShare,
 				owner_id: ownerId,
-				type
+				type,
+				shares_limit: SHARES_LOAD_LIMIT
 			},
 			skip:
 				flagged === undefined &&

--- a/src/carbonio-files-ui-common/hooks/graphql/queries/useGetChildQuery.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/queries/useGetChildQuery.ts
@@ -5,6 +5,7 @@
  */
 import { QueryResult, useQuery } from '@apollo/client';
 
+import { SHARES_LOAD_LIMIT } from '../../../constants';
 import GET_CHILD from '../../../graphql/queries/getChild.graphql';
 import { GetChildQuery, GetChildQueryVariables } from '../../../types/graphql/types';
 import { useErrorHandler } from '../../useErrorHandler';
@@ -14,7 +15,8 @@ export function useGetChildQuery(
 ): Pick<QueryResult<GetChildQuery, GetChildQueryVariables>, 'data' | 'error' | 'loading'> {
 	const { data, loading, error } = useQuery<GetChildQuery, GetChildQueryVariables>(GET_CHILD, {
 		variables: {
-			node_id: nodeId || ''
+			node_id: nodeId || '',
+			shares_limit: SHARES_LOAD_LIMIT
 		},
 		skip: !nodeId,
 		returnPartialData: true,

--- a/src/carbonio-files-ui-common/hooks/graphql/queries/useGetChildrenQuery.ts
+++ b/src/carbonio-files-ui-common/hooks/graphql/queries/useGetChildrenQuery.ts
@@ -10,7 +10,7 @@ import { QueryResult, useQuery, useReactiveVar } from '@apollo/client';
 import { isEqual } from 'lodash';
 
 import { nodeSortVar } from '../../../apollo/nodeSortVar';
-import { NODES_LOAD_LIMIT } from '../../../constants';
+import { NODES_LOAD_LIMIT, SHARES_LOAD_LIMIT } from '../../../constants';
 import GET_CHILDREN from '../../../graphql/queries/getChildren.graphql';
 import { GetChildrenQuery, GetChildrenQueryVariables } from '../../../types/graphql/types';
 import { isFolder } from '../../../utils/utils';
@@ -36,7 +36,8 @@ export function useGetChildrenQuery(parentNode: string): GetChildrenQueryHookRet
 			variables: {
 				node_id: parentNode,
 				children_limit: NODES_LOAD_LIMIT,
-				sort: nodeSort
+				sort: nodeSort,
+				shares_limit: SHARES_LOAD_LIMIT
 			},
 			skip: !parentNode,
 			errorPolicy: 'all',

--- a/src/carbonio-files-ui-common/hooks/useDeleteShareModal.tsx
+++ b/src/carbonio-files-ui-common/hooks/useDeleteShareModal.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-/* eslint-disable no-nested-ternary */
 import React, { useCallback } from 'react';
 
 import { FetchResult } from '@apollo/client';
@@ -12,12 +11,12 @@ import { Container, Text, useModal } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 
 import { TransText } from '../design_system_fork/TransText';
-import { DeleteNodesMutation, SharedTarget } from '../types/graphql/types';
+import { DeleteNodesMutation, ShareFragment } from '../types/graphql/types';
 import { InlineText } from '../views/components/StyledComponents';
 
 export function useDeleteShareModal(
 	deleteShareAction: () => Promise<FetchResult<DeleteNodesMutation>>,
-	shareTarget: SharedTarget,
+	shareTarget: NonNullable<ShareFragment['share_target']>,
 	isYourShare: boolean,
 	deleteShareActionCallback?: () => void
 ): {
@@ -47,11 +46,10 @@ export function useDeleteShareModal(
 							i18nKey="modal.deleteShare.body"
 							values={{
 								shareTarget:
-									shareTarget.__typename === 'DistributionList'
-										? shareTarget.name
-										: shareTarget.__typename === 'User'
-										? shareTarget.full_name || shareTarget.email
-										: ''
+									(shareTarget.__typename === 'DistributionList' && shareTarget.name) ||
+									(shareTarget.__typename === 'User' &&
+										(shareTarget.full_name || shareTarget.email)) ||
+									''
 							}}
 							overflow="break-word"
 							size="small"

--- a/src/carbonio-files-ui-common/mocks/mockUtils.ts
+++ b/src/carbonio-files-ui-common/mocks/mockUtils.ts
@@ -36,7 +36,7 @@ import {
 	Match,
 	Member
 } from '../types/network';
-import { MakeRequired } from '../types/utils';
+import { MakeRequired, MakeRequiredNonNull } from '../types/utils';
 import { ActionsFactoryNodeType } from '../utils/ActionsFactory';
 import { nodeSortComparator } from '../utils/utils';
 
@@ -104,7 +104,11 @@ export function populateSharePermission(sharePermission?: SharePermission): Shar
 	return sharePermission || SharePermission.ReadAndWrite;
 }
 
-export function populateShare(node: Node, key: number | string, shareTarget?: SharedTarget): Share {
+export function populateShare(
+	node: Node,
+	key: number | string,
+	shareTarget?: SharedTarget
+): MakeRequiredNonNull<Share, 'share_target'> {
 	return {
 		__typename: 'Share',
 		created_at: faker.date.past().getTime(),

--- a/src/carbonio-files-ui-common/types/graphql/types.ts
+++ b/src/carbonio-files-ui-common/types/graphql/types.ts
@@ -544,11 +544,11 @@ export type Child_File_Fragment = {
 		| ({
 				permission: SharePermission;
 				created_at: number;
+				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 				share_target?:
 					| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 					| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 					| null;
-				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 		  } & { __typename?: 'Share' })
 		| null
 	>;
@@ -597,11 +597,11 @@ export type Child_Folder_Fragment = {
 		| ({
 				permission: SharePermission;
 				created_at: number;
+				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 				share_target?:
 					| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 					| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 					| null;
-				node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 		  } & { __typename?: 'Share' })
 		| null
 	>;
@@ -664,7 +664,6 @@ export type ShareFragment = {
 		| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 		| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 		| null;
-	node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 } & { __typename?: 'Share' };
 
 export type ShareTargetFragment = { id: string } & { __typename?: 'DistributionList' | 'User' };
@@ -732,11 +731,11 @@ export type CopyNodesMutation = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -786,11 +785,11 @@ export type CopyNodesMutation = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -870,11 +869,11 @@ export type CreateFolderMutation = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -924,11 +923,11 @@ export type CreateFolderMutation = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -1193,11 +1192,11 @@ export type FindNodesQuery = {
 								| ({
 										permission: SharePermission;
 										created_at: number;
+										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 										share_target?:
 											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 											| null;
-										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 								  } & { __typename?: 'Share' })
 								| null
 							>;
@@ -1247,11 +1246,11 @@ export type FindNodesQuery = {
 								| ({
 										permission: SharePermission;
 										created_at: number;
+										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 										share_target?:
 											| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 											| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 											| null;
-										node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 								  } & { __typename?: 'Share' })
 								| null
 							>;
@@ -1389,11 +1388,11 @@ export type GetChildQuery = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -1443,11 +1442,11 @@ export type GetChildQuery = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -1521,13 +1520,13 @@ export type GetChildrenQuery = {
 									| ({
 											permission: SharePermission;
 											created_at: number;
+											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 											share_target?:
 												| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 												| ({ email: string; full_name: string; id: string } & {
 														__typename?: 'User';
 												  })
 												| null;
-											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 									  } & { __typename?: 'Share' })
 									| null
 								>;
@@ -1577,13 +1576,13 @@ export type GetChildrenQuery = {
 									| ({
 											permission: SharePermission;
 											created_at: number;
+											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 											share_target?:
 												| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 												| ({ email: string; full_name: string; id: string } & {
 														__typename?: 'User';
 												  })
 												| null;
-											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 									  } & { __typename?: 'Share' })
 									| null
 								>;
@@ -1665,11 +1664,11 @@ export type GetNodeQuery = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -1735,13 +1734,13 @@ export type GetNodeQuery = {
 									| ({
 											permission: SharePermission;
 											created_at: number;
+											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 											share_target?:
 												| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 												| ({ email: string; full_name: string; id: string } & {
 														__typename?: 'User';
 												  })
 												| null;
-											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 									  } & { __typename?: 'Share' })
 									| null
 								>;
@@ -1791,13 +1790,13 @@ export type GetNodeQuery = {
 									| ({
 											permission: SharePermission;
 											created_at: number;
+											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 											share_target?:
 												| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 												| ({ email: string; full_name: string; id: string } & {
 														__typename?: 'User';
 												  })
 												| null;
-											node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 									  } & { __typename?: 'Share' })
 									| null
 								>;
@@ -1844,11 +1843,11 @@ export type GetNodeQuery = {
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -2321,15 +2320,16 @@ export type GetSharesQuery = {
 	getNode?:
 		| ({
 				id: string;
+				type: NodeType;
 				shares: Array<
 					| ({
 							permission: SharePermission;
 							created_at: number;
+							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 							share_target?:
 								| ({ id: string; name: string } & { __typename?: 'DistributionList' })
 								| ({ email: string; full_name: string; id: string } & { __typename?: 'User' })
 								| null;
-							node: { id: string; type: NodeType } & { __typename?: 'File' | 'Folder' };
 					  } & { __typename?: 'Share' })
 					| null
 				>;
@@ -2440,7 +2440,35 @@ export const BaseNodeFragmentDoc = {
 				]
 			}
 		},
-		...PermissionsFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<BaseNodeFragment, unknown>;
 export const ShareFragmentDoc = {
@@ -2489,18 +2517,7 @@ export const ShareFragmentDoc = {
 							]
 						}
 					},
-					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
-					{
-						kind: 'Field',
-						name: { kind: 'Name', value: 'node' },
-						selectionSet: {
-							kind: 'SelectionSet',
-							selections: [
-								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
-								{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
-							]
-						}
-					}
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
 				]
 			}
 		}
@@ -2566,15 +2583,131 @@ export const ChildFragmentDoc = {
 						],
 						selectionSet: {
 							kind: 'SelectionSet',
-							selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
 						}
 					}
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions,
-		...PermissionsFragmentDoc.definitions,
-		...ShareFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<ChildFragment, unknown>;
 export const CollaborationLinkFragmentDoc = {
@@ -2817,7 +2950,188 @@ export const CopyNodesDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CopyNodesMutation, CopyNodesMutationVariables>;
 export const CreateCollaborationLinkDocument = {
@@ -2873,7 +3187,28 @@ export const CreateCollaborationLinkDocument = {
 				]
 			}
 		},
-		...CollaborationLinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollaborationLink' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'CollaborationLink' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	CreateCollaborationLinkMutation,
@@ -2936,7 +3271,188 @@ export const CreateFolderDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CreateFolderMutation, CreateFolderMutationVariables>;
 export const CreateLinkDocument = {
@@ -2997,7 +3513,29 @@ export const CreateLinkDocument = {
 				]
 			}
 		},
-		...LinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Link' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Link' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'expires_at' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<CreateLinkMutation, CreateLinkMutationVariables>;
 export const CreateShareDocument = {
@@ -4093,7 +4631,188 @@ export const FindNodesDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<FindNodesQuery, FindNodesQueryVariables>;
 export const GetAccountByEmailDocument = {
@@ -4267,7 +4986,64 @@ export const GetBaseNodeDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetBaseNodeQuery, GetBaseNodeQueryVariables>;
 export const GetChildDocument = {
@@ -4314,7 +5090,188 @@ export const GetChildDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetChildQuery, GetChildQueryVariables>;
 export const GetChildrenDocument = {
@@ -4434,7 +5391,188 @@ export const GetChildrenDocument = {
 				]
 			}
 		},
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetChildrenQuery, GetChildrenQueryVariables>;
 export const GetConfigsDocument = {
@@ -4615,7 +5753,23 @@ export const GetNodeDocument = {
 									],
 									selectionSet: {
 										kind: 'SelectionSet',
-										selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+										selections: [
+											{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'node' },
+												directives: [
+													{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }
+												],
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+													]
+												}
+											}
+										]
 									}
 								},
 								{
@@ -4673,10 +5827,188 @@ export const GetNodeDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions,
-		...PermissionsFragmentDoc.definitions,
-		...ShareFragmentDoc.definitions,
-		...ChildFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Child' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'BaseNode' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'owner' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'updated_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'last_editor' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'email' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'parent' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } }
+							]
+						}
+					},
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'shares' },
+						arguments: [
+							{
+								kind: 'Argument',
+								name: { kind: 'Name', value: 'limit' },
+								value: { kind: 'Variable', name: { kind: 'Name', value: 'shares_limit' } }
+							}
+						],
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+								{
+									kind: 'Field',
+									name: { kind: 'Name', value: 'node' },
+									directives: [{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }],
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+										]
+									}
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetNodeQuery, GetNodeQueryVariables>;
 export const GetNodeCollaborationLinksDocument = {
@@ -4729,7 +6061,28 @@ export const GetNodeCollaborationLinksDocument = {
 				]
 			}
 		},
-		...CollaborationLinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'CollaborationLink' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'CollaborationLink' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<
 	GetNodeCollaborationLinksQuery,
@@ -4783,7 +6136,29 @@ export const GetNodeLinksDocument = {
 				]
 			}
 		},
-		...LinkFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Link' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Link' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'url' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'description' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'expires_at' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'node' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetNodeLinksQuery, GetNodeLinksQueryVariables>;
 export const GetParentDocument = {
@@ -4846,7 +6221,64 @@ export const GetParentDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetParentQuery, GetParentQueryVariables>;
 export const GetPathDocument = {
@@ -4887,7 +6319,64 @@ export const GetPathDocument = {
 				]
 			}
 		},
-		...BaseNodeFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'BaseNode' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'name' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
+					{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Permissions' } },
+					{
+						kind: 'InlineFragment',
+						typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'File' } },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'size' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'mime_type' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'extension' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'version' } }
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'flagged' } },
+					{ kind: 'Field', name: { kind: 'Name', value: 'rootId' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetPathQuery, GetPathQueryVariables>;
 export const GetPermissionsDocument = {
@@ -4931,7 +6420,35 @@ export const GetPermissionsDocument = {
 				]
 			}
 		},
-		...PermissionsFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Permissions' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Node' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'permissions' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_file' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_write_folder' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_delete' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_add_version' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_link' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_read_share' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'can_change_share' } }
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetPermissionsQuery, GetPermissionsQueryVariables>;
 export const GetRootsListDocument = {
@@ -5018,6 +6535,7 @@ export const GetSharesDocument = {
 							kind: 'SelectionSet',
 							selections: [
 								{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+								{ kind: 'Field', name: { kind: 'Name', value: 'type' } },
 								{
 									kind: 'Field',
 									name: { kind: 'Name', value: 'shares' },
@@ -5040,7 +6558,23 @@ export const GetSharesDocument = {
 									],
 									selectionSet: {
 										kind: 'SelectionSet',
-										selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } }]
+										selections: [
+											{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'Share' } },
+											{
+												kind: 'Field',
+												name: { kind: 'Name', value: 'node' },
+												directives: [
+													{ kind: 'Directive', name: { kind: 'Name', value: 'client' } }
+												],
+												selectionSet: {
+													kind: 'SelectionSet',
+													selections: [
+														{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+														{ kind: 'Field', name: { kind: 'Name', value: 'type' } }
+													]
+												}
+											}
+										]
 									}
 								}
 							]
@@ -5049,7 +6583,53 @@ export const GetSharesDocument = {
 				]
 			}
 		},
-		...ShareFragmentDoc.definitions
+		{
+			kind: 'FragmentDefinition',
+			name: { kind: 'Name', value: 'Share' },
+			typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'Share' } },
+			selectionSet: {
+				kind: 'SelectionSet',
+				selections: [
+					{ kind: 'Field', name: { kind: 'Name', value: 'permission' } },
+					{
+						kind: 'Field',
+						name: { kind: 'Name', value: 'share_target' },
+						selectionSet: {
+							kind: 'SelectionSet',
+							selections: [
+								{
+									kind: 'InlineFragment',
+									typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'email' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'full_name' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } }
+										]
+									}
+								},
+								{
+									kind: 'InlineFragment',
+									typeCondition: {
+										kind: 'NamedType',
+										name: { kind: 'Name', value: 'DistributionList' }
+									},
+									selectionSet: {
+										kind: 'SelectionSet',
+										selections: [
+											{ kind: 'Field', name: { kind: 'Name', value: 'id' } },
+											{ kind: 'Field', name: { kind: 'Name', value: 'name' } }
+										]
+									}
+								}
+							]
+						}
+					},
+					{ kind: 'Field', name: { kind: 'Name', value: 'created_at' } }
+				]
+			}
+		}
 	]
 } as unknown as DocumentNode<GetSharesQuery, GetSharesQueryVariables>;
 export const GetUploadItemDocument = {

--- a/src/carbonio-files-ui-common/types/utils.ts
+++ b/src/carbonio-files-ui-common/types/utils.ts
@@ -11,7 +11,11 @@ export type OneOrMany<T> = T | T[];
 export type ArrayOneOrMore<T> = [T] & T[];
 
 export type DeepPick<T, K extends keyof T, KK extends keyof NonNullable<T[K]>> = {
-	[P in K]: T[P] extends Record<KK, unknown> ? Pick<T[P], KK> : T[P];
+	[P in K]: T[P] extends Record<KK, unknown>
+		? T[P] extends null | undefined
+			? Pick<NonNullable<T[P]>, KK> | null | undefined
+			: Pick<NonNullable<T[P]>, KK>
+		: T[P];
 };
 
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: T[SubKey] };
@@ -33,6 +37,10 @@ export type NonNullableList<T extends Array<unknown>> = Array<NonNullable<Unwrap
 export type NonNullableListItem<T extends Array<unknown>> = Unwrap<NonNullableList<T>>;
 
 export type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+
+export type MakeRequiredNonNull<T, K extends keyof T> = T & { [KK in K]-?: NonNullable<T[KK]> };
+
+export type MakePartial<T, K extends keyof T> = Omit<T, K> & { [KK in K]: Partial<T[KK]> };
 
 export type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
 	? `${T}${Capitalize<SnakeToCamelCase<U>>}`

--- a/src/carbonio-files-ui-common/utils/mockUtils.ts
+++ b/src/carbonio-files-ui-common/utils/mockUtils.ts
@@ -157,7 +157,7 @@ export function getFindNodesVariables(
 		limit: NODES_LOAD_LIMIT,
 		sort: NODES_SORT_DEFAULT,
 		page_token: withCursor ? 'next_page_token' : undefined,
-		shares_limit: 1,
+		shares_limit: SHARES_LOAD_LIMIT,
 		...variables
 	};
 }
@@ -337,7 +337,7 @@ export function getChildrenVariables(
 	folderId: Id,
 	childrenLimit = NODES_LOAD_LIMIT,
 	sort = NODES_SORT_DEFAULT,
-	sharesLimit = 1,
+	sharesLimit = SHARES_LOAD_LIMIT,
 	withCursor = false
 ): GetChildrenQueryVariables {
 	return {
@@ -413,7 +413,7 @@ export function mockCopyNodes(
 	return {
 		request: {
 			query: COPY_NODES,
-			variables: { ...variables, shares_limit: 1 }
+			variables: { ...variables, shares_limit: SHARES_LOAD_LIMIT }
 		},
 		result: {
 			data: {
@@ -433,7 +433,7 @@ export function mockCreateFolder(
 	return {
 		request: {
 			query: CREATE_FOLDER,
-			variables: { ...variables, shares_limit: 1 }
+			variables: { ...variables, shares_limit: SHARES_LOAD_LIMIT }
 		},
 		result: {
 			data: {
@@ -450,7 +450,7 @@ export function mockCreateFolderError(
 	return {
 		request: {
 			query: CREATE_FOLDER,
-			variables: { ...variables, shares_limit: 1 }
+			variables: { ...variables, shares_limit: SHARES_LOAD_LIMIT }
 		},
 		error
 	};
@@ -948,7 +948,7 @@ export function mockGetChild(
 			query: GET_CHILD,
 			variables: {
 				node_id: variables.node_id,
-				shares_limit: variables?.shares_limit || 1
+				shares_limit: variables?.shares_limit || SHARES_LOAD_LIMIT
 			}
 		},
 		result: {

--- a/src/carbonio-files-ui-common/utils/uploadUtils.ts
+++ b/src/carbonio-files-ui-common/utils/uploadUtils.ts
@@ -13,7 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { encodeBase64, isFileSystemDirectoryEntry, isFolder, TreeNode } from './utils';
 import { UploadFunctions, uploadFunctionsVar, UploadRecord, uploadVar } from '../apollo/uploadVar';
-import { REST_ENDPOINT, UPLOAD_PATH, UPLOAD_VERSION_PATH } from '../constants';
+import { REST_ENDPOINT, SHARES_LOAD_LIMIT, UPLOAD_PATH, UPLOAD_VERSION_PATH } from '../constants';
 import GET_CHILD from '../graphql/queries/getChild.graphql';
 import GET_CHILDREN from '../graphql/queries/getChildren.graphql';
 import GET_VERSIONS from '../graphql/queries/getVersions.graphql';
@@ -314,7 +314,8 @@ function loadItemAsChild(
 				query: GET_CHILD,
 				fetchPolicy: 'no-cache',
 				variables: {
-					node_id: nodeId as string
+					node_id: nodeId,
+					shares_limit: SHARES_LOAD_LIMIT
 				}
 			})
 			.then((result) => {

--- a/src/carbonio-files-ui-common/utils/utils.ts
+++ b/src/carbonio-files-ui-common/utils/utils.ts
@@ -57,6 +57,7 @@ import {
 	NodeType,
 	SharePermission
 } from '../types/graphql/types';
+import { MakeRequiredNonNull } from '../types/utils';
 
 /**
  * Format a size in byte as human-readable
@@ -846,12 +847,12 @@ export function cssCalcBuilder(
 
 export function isFile(
 	node: ({ __typename?: string } & Record<string, unknown>) | null | undefined
-): node is File {
+): node is File & MakeRequiredNonNull<File, '__typename'> {
 	return node?.__typename === 'File';
 }
 
 export function isFolder(
 	node: ({ __typename?: string } & Record<string, unknown>) | null | undefined
-): node is Folder {
+): node is Folder & MakeRequiredNonNull<Folder, '__typename'> {
 	return node?.__typename === 'Folder';
 }

--- a/src/carbonio-files-ui-common/views/FilterView.flagged.test.tsx
+++ b/src/carbonio-files-ui-common/views/FilterView.flagged.test.tsx
@@ -12,7 +12,13 @@ import { Route } from 'react-router-dom';
 import FilterView from './FilterView';
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import server from '../../mocks/server';
-import { FILTER_TYPE, INTERNAL_PATH, NODES_LOAD_LIMIT, ROOTS } from '../constants';
+import {
+	FILTER_TYPE,
+	INTERNAL_PATH,
+	NODES_LOAD_LIMIT,
+	ROOTS,
+	SHARES_LOAD_LIMIT
+} from '../constants';
 import handleFindNodesRequest from '../mocks/handleFindNodesRequest';
 import { populateNodes } from '../mocks/mockUtils';
 import { FindNodesQuery, FindNodesQueryVariables, NodeSort } from '../types/graphql/types';
@@ -49,7 +55,7 @@ describe('Filter view', () => {
 				cascade: true,
 				sort: NodeSort.NameAsc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1
+				shares_limit: SHARES_LOAD_LIMIT
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/src/carbonio-files-ui-common/views/FilterView.recents.test.tsx
+++ b/src/carbonio-files-ui-common/views/FilterView.recents.test.tsx
@@ -12,7 +12,14 @@ import { Route } from 'react-router-dom';
 import FilterView from './FilterView';
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import server from '../../mocks/server';
-import { FILTER_PARAMS, FILTER_TYPE, INTERNAL_PATH, NODES_LOAD_LIMIT, ROOTS } from '../constants';
+import {
+	FILTER_PARAMS,
+	FILTER_TYPE,
+	INTERNAL_PATH,
+	NODES_LOAD_LIMIT,
+	ROOTS,
+	SHARES_LOAD_LIMIT
+} from '../constants';
 import handleFindNodesRequest from '../mocks/handleFindNodesRequest';
 import { populateNodes } from '../mocks/mockUtils';
 import { FindNodesQuery, FindNodesQueryVariables, NodeSort } from '../types/graphql/types';
@@ -47,7 +54,7 @@ describe('Filter View', () => {
 				cascade: true,
 				sort: NodeSort.UpdatedAtDesc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1
+				shares_limit: SHARES_LOAD_LIMIT
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/src/carbonio-files-ui-common/views/FilterView.sharedByMe.test.tsx
+++ b/src/carbonio-files-ui-common/views/FilterView.sharedByMe.test.tsx
@@ -13,7 +13,13 @@ import { Route } from 'react-router-dom';
 import FilterView from './FilterView';
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import server from '../../mocks/server';
-import { FILTER_TYPE, INTERNAL_PATH, NODES_LOAD_LIMIT, ROOTS } from '../constants';
+import {
+	FILTER_TYPE,
+	INTERNAL_PATH,
+	NODES_LOAD_LIMIT,
+	ROOTS,
+	SHARES_LOAD_LIMIT
+} from '../constants';
 import handleFindNodesRequest from '../mocks/handleFindNodesRequest';
 import { populateNode, populateNodes, populateShares } from '../mocks/mockUtils';
 import {
@@ -65,7 +71,7 @@ describe('Filter view', () => {
 				shared_by_me: true,
 				sort: NodeSort.NameAsc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1,
+				shares_limit: SHARES_LOAD_LIMIT,
 				direct_share: true
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(

--- a/src/carbonio-files-ui-common/views/FilterView.sharedWithMe.test.tsx
+++ b/src/carbonio-files-ui-common/views/FilterView.sharedWithMe.test.tsx
@@ -12,7 +12,13 @@ import { Route } from 'react-router-dom';
 import FilterView from './FilterView';
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import server from '../../mocks/server';
-import { FILTER_TYPE, INTERNAL_PATH, NODES_LOAD_LIMIT, ROOTS } from '../constants';
+import {
+	FILTER_TYPE,
+	INTERNAL_PATH,
+	NODES_LOAD_LIMIT,
+	ROOTS,
+	SHARES_LOAD_LIMIT
+} from '../constants';
 import handleFindNodesRequest from '../mocks/handleFindNodesRequest';
 import { populateNodes, populateShare, populateUser } from '../mocks/mockUtils';
 import { Node } from '../types/common';
@@ -59,7 +65,7 @@ describe('Filter view', () => {
 				shared_with_me: true,
 				sort: NodeSort.NameAsc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1,
+				shares_limit: SHARES_LOAD_LIMIT,
 				direct_share: true
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(

--- a/src/carbonio-files-ui-common/views/FilterView.trash.test.tsx
+++ b/src/carbonio-files-ui-common/views/FilterView.trash.test.tsx
@@ -13,7 +13,13 @@ import { Route } from 'react-router-dom';
 import FilterView from './FilterView';
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import server from '../../mocks/server';
-import { FILTER_TYPE, INTERNAL_PATH, NODES_LOAD_LIMIT, ROOTS } from '../constants';
+import {
+	FILTER_TYPE,
+	INTERNAL_PATH,
+	NODES_LOAD_LIMIT,
+	ROOTS,
+	SHARES_LOAD_LIMIT
+} from '../constants';
 import { ACTION_REGEXP, ICON_REGEXP, SELECTORS } from '../constants/test';
 import FIND_NODES from '../graphql/queries/findNodes.graphql';
 import GET_NODE from '../graphql/queries/getNode.graphql';
@@ -328,7 +334,7 @@ describe('Filter view', () => {
 				shared_with_me: false,
 				sort: NodeSort.NameAsc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1
+				shares_limit: SHARES_LOAD_LIMIT
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -353,7 +359,7 @@ describe('Filter view', () => {
 				shared_with_me: true,
 				sort: NodeSort.NameAsc,
 				limit: NODES_LOAD_LIMIT,
-				shares_limit: 1
+				shares_limit: SHARES_LOAD_LIMIT
 			};
 			expect(mockedRequestHandler).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/src/carbonio-files-ui-common/views/SearchView.test.tsx
+++ b/src/carbonio-files-ui-common/views/SearchView.test.tsx
@@ -211,7 +211,7 @@ describe('Search view', () => {
 				mockGetPath({ node_id: node.parent.id }, parentPath),
 				mockGetPath({ node_id: destinationFolder.id }, [...parentPath, destinationFolder]),
 				mockGetChildren(getChildrenVariables(node.parent.id), node.parent),
-				mockGetChild({ node_id: node.parent.id, shares_limit: 1 }, node.parent),
+				mockGetChild({ node_id: node.parent.id }, node.parent),
 				mockMoveNodes({ node_ids: [node.id], destination_id: destinationFolder.id }, [node])
 			];
 

--- a/src/carbonio-files-ui-common/views/components/FolderSelectionModalContent.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/FolderSelectionModalContent.test.tsx
@@ -499,7 +499,7 @@ describe('Folder Selection Modal Content', () => {
 				filter
 			),
 			mockGetChildren(getChildrenVariables(folder.id), folder),
-			mockGetChild({ node_id: folder.id, shares_limit: 1 }, folder),
+			mockGetChild({ node_id: folder.id }, folder),
 			mockGetPath({ node_id: folder.id }, [folder])
 		];
 

--- a/src/carbonio-files-ui-common/views/components/List.contextualMenuActions.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/List.contextualMenuActions.test.tsx
@@ -68,7 +68,7 @@ describe('Contextual menu actions', () => {
 
 				const mocks = [
 					mockGetParent({ node_id: currentFolder.id }, currentFolder),
-					mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+					mockGetChild({ node_id: currentFolder.id }, currentFolder)
 				];
 
 				const { user } = setup(
@@ -173,7 +173,7 @@ describe('Contextual menu actions', () => {
 
 				const mocks = [
 					mockGetParent({ node_id: currentFolder.id }, currentFolder),
-					mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+					mockGetChild({ node_id: currentFolder.id }, currentFolder)
 				];
 
 				const { user } = setup(
@@ -275,7 +275,7 @@ describe('Contextual menu actions', () => {
 
 				const mocks = [
 					mockGetParent({ node_id: currentFolder.id }, currentFolder),
-					mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+					mockGetChild({ node_id: currentFolder.id }, currentFolder)
 				];
 
 				const { user } = setup(
@@ -375,7 +375,7 @@ describe('Contextual menu actions', () => {
 
 				const mocks = [
 					mockGetParent({ node_id: currentFolder.id }, currentFolder),
-					mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+					mockGetChild({ node_id: currentFolder.id }, currentFolder)
 				];
 
 				const { user } = setup(
@@ -449,7 +449,7 @@ describe('Contextual menu actions', () => {
 
 			const mocks = [
 				mockGetParent({ node_id: currentFolder.id }, currentFolder),
-				mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+				mockGetChild({ node_id: currentFolder.id }, currentFolder)
 			];
 
 			const { user } = setup(
@@ -502,7 +502,7 @@ describe('Contextual menu actions', () => {
 
 			const mocks = [
 				mockGetParent({ node_id: currentFolder.id }, currentFolder),
-				mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+				mockGetChild({ node_id: currentFolder.id }, currentFolder)
 			];
 
 			const { user } = setup(
@@ -567,7 +567,7 @@ describe('Contextual menu actions', () => {
 
 		const mocks = [
 			mockGetParent({ node_id: currentFolder.id }, currentFolder),
-			mockGetChild({ node_id: currentFolder.id, shares_limit: 1 }, currentFolder)
+			mockGetChild({ node_id: currentFolder.id }, currentFolder)
 		];
 
 		const { user } = setup(

--- a/src/carbonio-files-ui-common/views/components/NodesSelectionModalContent.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/NodesSelectionModalContent.test.tsx
@@ -1213,7 +1213,7 @@ describe('Nodes Selection Modal Content', () => {
 					mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 					mockGetPath({ node_id: localRoot.id }, [localRoot]),
 					mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-					mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+					mockGetChild({ node_id: localRoot.id }, localRoot),
 					mockGetPermissions({ node_id: localRoot.id }, localRoot)
 				];
 
@@ -2174,7 +2174,7 @@ describe('Nodes Selection Modal Content', () => {
 					mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 					mockGetPath({ node_id: localRoot.id }, [localRoot]),
 					mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-					mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+					mockGetChild({ node_id: localRoot.id }, localRoot),
 					mockGetPermissions({ node_id: localRoot.id }, localRoot)
 				];
 
@@ -2555,7 +2555,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot)
 			];
 
@@ -2609,7 +2609,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot)
 			];
 
@@ -2675,7 +2675,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: sharedFolder.id }, [sharedFolder]),
 				mockGetBaseNode({ node_id: sharedFolder.id }, sharedFolder),
 				mockGetChildren(getChildrenVariables(sharedFolder.id), sharedFolder),
-				mockGetChild({ node_id: sharedFolder.id, shares_limit: 1 }, sharedFolder),
+				mockGetChild({ node_id: sharedFolder.id }, sharedFolder),
 				mockGetPermissions({ node_id: sharedFolder.id }, sharedFolder)
 			];
 
@@ -2746,7 +2746,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: sharedFolder.id }, [sharedFolder]),
 				mockGetBaseNode({ node_id: sharedFolder.id }, sharedFolder),
 				mockGetChildren(getChildrenVariables(sharedFolder.id), sharedFolder),
-				mockGetChild({ node_id: sharedFolder.id, shares_limit: 1 }, sharedFolder),
+				mockGetChild({ node_id: sharedFolder.id }, sharedFolder),
 				mockGetPermissions({ node_id: sharedFolder.id }, sharedFolder)
 			];
 
@@ -2818,12 +2818,12 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot),
 				mockGetPath({ node_id: folder.id }, [localRoot, folder]),
 				mockGetBaseNode({ node_id: folder.id }, folder),
 				mockGetChildren(getChildrenVariables(folder.id), folder),
-				mockGetChild({ node_id: folder.id, shares_limit: 1 }, folder),
+				mockGetChild({ node_id: folder.id }, folder),
 				mockGetPermissions({ node_id: folder.id }, folder)
 			];
 
@@ -2904,7 +2904,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot),
 				mockGetBaseNode({ node_id: folder.id }, folder)
 			];
@@ -2988,7 +2988,7 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot),
 				mockCreateFolder({ name: newFolder.name, destination_id: localRoot.id }, newFolder),
 				mockGetBaseNode({ node_id: newFolder.id }, newFolder)
@@ -3211,12 +3211,12 @@ describe('Nodes Selection Modal Content', () => {
 				mockGetPath({ node_id: localRoot.id }, [localRoot]),
 				mockGetBaseNode({ node_id: localRoot.id }, localRoot),
 				mockGetChildren(getChildrenVariables(localRoot.id), localRoot),
-				mockGetChild({ node_id: localRoot.id, shares_limit: 1 }, localRoot),
+				mockGetChild({ node_id: localRoot.id }, localRoot),
 				mockGetPermissions({ node_id: localRoot.id }, localRoot),
 				mockGetPath({ node_id: folder.id }, [localRoot, folder]),
 				mockGetBaseNode({ node_id: folder.id }, folder),
 				mockGetChildren(getChildrenVariables(folder.id), folder),
-				mockGetChild({ node_id: folder.id, shares_limit: 1 }, folder),
+				mockGetChild({ node_id: folder.id }, folder),
 				mockGetPermissions({ node_id: folder.id }, folder)
 			];
 

--- a/src/carbonio-files-ui-common/views/components/sharing/NodeSharing.tsx
+++ b/src/carbonio-files-ui-common/views/components/sharing/NodeSharing.tsx
@@ -30,6 +30,7 @@ import { useDeleteShareMutation } from '../../../hooks/graphql/mutations/useDele
 import { useGetSharesQuery } from '../../../hooks/graphql/queries/useGetSharesQuery';
 import { Node } from '../../../types/common';
 import { Share, SharedTarget } from '../../../types/graphql/types';
+import { MakePartial, MakeRequiredNonNull } from '../../../types/utils';
 import { cssCalcBuilder, getChipLabel, getChipTooltip, isFile } from '../../../utils/utils';
 
 const MainContainer = styled(Container)`
@@ -53,12 +54,17 @@ const CustomText = styled(Text)`
 interface NodeSharingProps {
 	node: Pick<Node, '__typename' | 'id' | 'permissions' | 'owner' | 'name'> & {
 		shares?: Array<
-			// eslint-disable-next-line camelcase
 			| (Pick<Share, '__typename'> & { shared_target?: Pick<SharedTarget, '__typename' | 'id'> })
 			| null
 			| undefined
 		>;
 	};
+}
+
+function shareTargetExists<T extends MakePartial<Pick<Share, 'share_target'>, 'share_target'>>(
+	share: T
+): share is T & MakeRequiredNonNull<T, 'share_target'> {
+	return share.share_target !== undefined && share.share_target !== null;
 }
 
 export const NodeSharing: React.VFC<NodeSharingProps> = ({ node }) => {
@@ -74,11 +80,11 @@ export const NodeSharing: React.VFC<NodeSharingProps> = ({ node }) => {
 			reduce(
 				data?.getNode?.shares,
 				(accumulator, share) => {
-					if (share?.share_target) {
+					if (share && shareTargetExists(share)) {
 						const chip = (
 							<EditShareChip
 								key={`${share.share_target.id}`}
-								share={share as Share}
+								share={share}
 								permissions={node.permissions}
 								yourselfChip={share.share_target.id === me}
 								deleteShare={deleteShare}
@@ -124,7 +130,7 @@ export const NodeSharing: React.VFC<NodeSharingProps> = ({ node }) => {
 	return (
 		<MainContainer
 			mainAlignment="flex-start"
-			background="gray5"
+			background={'gray5'}
 			height={cssCalcBuilder('100%', ['-', '3.125rem'])}
 			data-testid="node-sharing"
 		>
@@ -133,14 +139,14 @@ export const NodeSharing: React.VFC<NodeSharingProps> = ({ node }) => {
 				crossAlignment="flex-start"
 				height="fit"
 				padding={{ all: 'large' }}
-				background="gray6"
+				background={'gray6'}
 				data-testid="node-sharing-collaborators"
 			>
 				{!node.permissions.can_share && (
 					<Padding bottom="large" width="100%">
 						<Container
 							orientation="horizontal"
-							background="info"
+							background={'info'}
 							minHeight="2.5rem"
 							mainAlignment="flex-start"
 						>
@@ -193,7 +199,7 @@ export const NodeSharing: React.VFC<NodeSharingProps> = ({ node }) => {
 				<PublicLink
 					nodeId={node.id}
 					nodeName={node.name}
-					nodeTypename={node.__typename as string}
+					nodeTypename={node.__typename}
 					canShare={node.permissions.can_share}
 				/>
 			)}


### PR DESCRIPTION
Shares are queried from a getNode, so the node is already available when reading the shares field. Avoid asking for the node field from network, read it from cache instead.

refs: FILES-477