### PR TITLE
chore: add restriction on shell import from common files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,22 @@ module.exports = {
 			rules: {
 				'import/no-extraneous-dependencies': 'off'
 			}
+		},
+		{
+			files: 'src/carbonio-files-ui-common/**/*.[jt]s?(x)',
+			rules: {
+				'no-restricted-imports': [
+					'error',
+					{
+						paths: [
+							{
+								name: '@zextras/carbonio-shell-ui',
+								message: 'Do not import shell in common files'
+							}
+						]
+					}
+				]
+			}
 		}
 	],
 	parserOptions: {


### PR DESCRIPTION
The rule set in eslint prevents the usage of shell directly from the common files. This enforces the structure used until now of keeping the core independent from the environment, and prevent accidental mistakes.