### PR TITLE
ci: add build:dev script for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"lint": "eslint --ext .js,.jsx,.ts,.tsx,.graphql --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"generate": "graphql-codegen",
 		"translations:push": "git subtree push --prefix translations $npm_package_config_translations_repository translations-updater/$(date '+%Y-%m-%d')",
-		"translations:pull": "git subtree pull --squash --prefix translations $npm_package_config_translations_repository master"
+		"translations:pull": "git subtree pull --squash --prefix translations $npm_package_config_translations_repository master",
+		"build:dev": "sdk build --dev --pkgRel $(date +%s)"
 	},
 	"keywords": [],
 	"author": "",


### PR DESCRIPTION
To make common pipeline support different bundlers, we need to remove references to the sdk from it and move them inside projects scripts. build:dev is the script in charge of creating the build in dev mode.
Related to zextras/jenkins-zapp-lib#13 