### PR TITLE
fix: translate unit measures for size

### DIFF
--- a/src/carbonio-files-ui-common/mocks/mockUtils.ts
+++ b/src/carbonio-files-ui-common/mocks/mockUtils.ts
@@ -327,7 +327,7 @@ export function populateFile(id?: string, name?: string): MakeRequiredNonNull<Fi
 	const file: MakeRequiredNonNull<FilesFile, 'owner'> = {
 		...populateNodeFields(faker.helpers.arrayElement(types), id, name),
 		mime_type: mimeType,
-		size: faker.number.float(),
+		size: faker.number.int(),
 		extension: faker.system.commonFileExt(),
 		version: 1,
 		parent: populateFolder(),

--- a/src/carbonio-files-ui-common/utils/utils.test.ts
+++ b/src/carbonio-files-ui-common/utils/utils.test.ts
@@ -223,12 +223,12 @@ describe('CssCalc builder', () => {
 
 describe('humanFileSize function', () => {
 	it('should return 0 B if input is 0', () => {
-		const result = humanFileSize(0);
+		const result = humanFileSize(0, undefined);
 		expect(result).toBe('0 B');
 	});
 
 	it('should return x if input is max safe integer', () => {
-		const result = humanFileSize(Number.MAX_SAFE_INTEGER);
+		const result = humanFileSize(Number.MAX_SAFE_INTEGER, undefined);
 		expect(result).toBe('8.00 PB');
 	});
 
@@ -243,7 +243,7 @@ describe('humanFileSize function', () => {
 		['ZB', 7],
 		['YB', 8]
 	])('should return %s unit if input pow is %s', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow);
+		const result = humanFileSize(1024 ** pow, undefined);
 		expect(result).toBe(`1.00 ${unit}`);
 	});
 
@@ -259,13 +259,13 @@ describe('humanFileSize function', () => {
 	])(
 		'should return %s unit measure if input is one unit lower than the next unit measure',
 		(unit, pow) => {
-			const result = humanFileSize(1024 ** pow - 1024 ** (pow - 1));
+			const result = humanFileSize(1024 ** pow - 1024 ** (pow - 1), undefined);
 			expect(result).toBe(`1023.00 ${unit}`);
 		}
 	);
 
 	it('should change unit from KB to B when removing 1 B from 1024 B', () => {
-		expect(humanFileSize(1024 - 1)).toBe('1023.00 B');
+		expect(humanFileSize(1024 - 1, undefined)).toBe('1023.00 B');
 	});
 
 	it.each([
@@ -273,7 +273,7 @@ describe('humanFileSize function', () => {
 		['MB', 3],
 		['GB', 4]
 	])('should return 1024.00 %s if input is 1024 ** %s - 1', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow - 1);
+		const result = humanFileSize(1024 ** pow - 1, undefined);
 		expect(result).toBe(`1024.00 ${unit}`);
 	});
 
@@ -283,11 +283,11 @@ describe('humanFileSize function', () => {
 		['ZB', 7],
 		['YB', 8]
 	])('should return %s unit if input pow is %s - 1B', (unit, pow) => {
-		const result = humanFileSize(1024 ** pow - 1);
+		const result = humanFileSize(1024 ** pow - 1, undefined);
 		expect(result).toBe(`1.00 ${unit}`);
 	});
 
 	it('should throw an error if inputSize is equal or greater than 1024 YB', () => {
-		expect(() => humanFileSize(1024 ** 9)).toThrow('Unsupported inputSize');
+		expect(() => humanFileSize(1024 ** 9, undefined)).toThrow('Unsupported inputSize');
 	});
 });

--- a/src/carbonio-files-ui-common/utils/utils.test.ts
+++ b/src/carbonio-files-ui-common/utils/utils.test.ts
@@ -227,7 +227,7 @@ describe('humanFileSize function', () => {
 		expect(result).toBe('0 B');
 	});
 
-	it('should return x if input is max safe integer', () => {
+	it('should return 8.00 PB if input is max safe integer', () => {
 		const result = humanFileSize(Number.MAX_SAFE_INTEGER, undefined);
 		expect(result).toBe('8.00 PB');
 	});

--- a/src/carbonio-files-ui-common/utils/utils.ts
+++ b/src/carbonio-files-ui-common/utils/utils.ts
@@ -11,18 +11,7 @@ import { NetworkError } from '@apollo/client/errors';
 import { GraphQLError } from 'graphql';
 import type { Location } from 'history';
 import { TFunction } from 'i18next';
-import {
-	chain,
-	debounce,
-	findIndex,
-	forEach,
-	isEmpty,
-	map,
-	reduce,
-	size,
-	toLower,
-	trim
-} from 'lodash';
+import { chain, debounce, findIndex, forEach, isEmpty, map, reduce, toLower, trim } from 'lodash';
 import { DefaultTheme } from 'styled-components';
 
 import {
@@ -64,16 +53,20 @@ import type { NodeListItemUIProps } from '../views/components/NodeListItemUI';
  * Format a size in byte as human-readable
  */
 export const humanFileSize = (inputSize: number, t: TFunction | undefined): string => {
+	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 	if (inputSize === 0) {
-		return '0 B';
+		const unit = units[0];
+		const unitTranslated = t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit;
+		return `0 ${unitTranslated}`;
 	}
 	const i = Math.floor(Math.log(inputSize) / Math.log(1024));
-	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 	if (i >= units.length) {
 		throw new Error('Unsupported inputSize');
 	}
-	const unit = units[i];
-	return `${(inputSize / 1024 ** i).toFixed(2).toString()} ${t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit}`;
+	const unit = units[i >= 0 ? i : 0];
+	const unitTranslated = t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit;
+	const size = (inputSize / 1024 ** i).toFixed(2).toString();
+	return `${size} ${unitTranslated}`;
 };
 
 function getIconByRootId(rootId: Maybe<string> | undefined): keyof DefaultTheme['icons'] {
@@ -683,7 +676,7 @@ export async function scan(item: FileSystemEntry): Promise<TreeNode> {
 			// https://eslint.org/docs/latest/rules/no-await-in-loop#:~:text=In%20many%20cases%20the%20iterations%20of%20a%20loop%20are%20not%20actually%20independent%20of%20each%2Dother.%20For%20example%2C%20the%20output%20of%20one%20iteration%20might%20be%20used%20as%20the%20input%20to%20another
 			// eslint-disable-next-line no-await-in-loop
 			const newEntries = await readEntries(directoryReader);
-			if (size(newEntries) === 0) {
+			if (newEntries.length === 0) {
 				flag = false;
 			} else {
 				entries.push(...newEntries);

--- a/src/carbonio-files-ui-common/utils/utils.ts
+++ b/src/carbonio-files-ui-common/utils/utils.ts
@@ -63,7 +63,7 @@ import type { NodeListItemUIProps } from '../views/components/NodeListItemUI';
 /**
  * Format a size in byte as human-readable
  */
-export const humanFileSize = (inputSize: number): string => {
+export const humanFileSize = (inputSize: number, t: TFunction | undefined): string => {
 	if (inputSize === 0) {
 		return '0 B';
 	}
@@ -72,7 +72,8 @@ export const humanFileSize = (inputSize: number): string => {
 	if (i >= units.length) {
 		throw new Error('Unsupported inputSize');
 	}
-	return `${(inputSize / 1024 ** i).toFixed(2).toString()} ${units[i]}`;
+	const unit = units[i];
+	return `${(inputSize / 1024 ** i).toFixed(2).toString()} ${t ? t('size.unitMeasure', { context: unit, defaultValue: unit }) : unit}`;
 };
 
 function getIconByRootId(rootId: Maybe<string> | undefined): keyof DefaultTheme['icons'] {

--- a/src/carbonio-files-ui-common/views/components/FilesQuota.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/FilesQuota.test.tsx
@@ -35,7 +35,7 @@ describe('Files Quota', () => {
 				responseReceived: true,
 				refreshData: jest.fn()
 			});
-			const quotaString = `${humanFileSize(used)} of unlimited space`;
+			const quotaString = `${humanFileSize(used, undefined)} of unlimited space`;
 
 			setup(<FilesQuota />);
 
@@ -85,7 +85,7 @@ describe('Files Quota', () => {
 				responseReceived: true,
 				refreshData: jest.fn()
 			});
-			const quotaString = `${humanFileSize(used)} of ${humanFileSize(limit)} used`;
+			const quotaString = `${humanFileSize(used, undefined)} of ${humanFileSize(limit, undefined)} used`;
 
 			setup(<FilesQuota />);
 
@@ -287,9 +287,10 @@ describe('Files Quota', () => {
 			const limit = 100;
 			const quotaUsed = 50;
 			const updatedQuotaUsed = 99;
-			const quotaString = `${humanFileSize(quotaUsed)} of ${humanFileSize(limit)} used`;
-			const updatedQuotaString = `${humanFileSize(updatedQuotaUsed)} of ${humanFileSize(
-				limit
+			const quotaString = `${humanFileSize(quotaUsed, undefined)} of ${humanFileSize(limit, undefined)} used`;
+			const updatedQuotaString = `${humanFileSize(updatedQuotaUsed, undefined)} of ${humanFileSize(
+				limit,
+				undefined
 			)} used`;
 			const mockMySelfQuota = jest
 				.spyOn(mySelfQuotaModule, 'mySelfQuota')
@@ -308,14 +309,14 @@ describe('Files Quota', () => {
 
 		it.each([
 			[0, 'unlimited space'],
-			[100, `${humanFileSize(100)} used`]
+			[100, `${humanFileSize(100, undefined)} used`]
 		])(
 			'should refresh the quota data when the user clicks on the refresh button (limit: %s)',
 			async (limit, description) => {
 				const quotaUsed = 50;
 				const updatedQuotaUsed = 99;
-				const quotaString = `${humanFileSize(quotaUsed)} of ${description}`;
-				const updatedQuotaString = `${humanFileSize(updatedQuotaUsed)} of ${description}`;
+				const quotaString = `${humanFileSize(quotaUsed, undefined)} of ${description}`;
+				const updatedQuotaString = `${humanFileSize(updatedQuotaUsed, undefined)} of ${description}`;
 				const mockMySelfQuota = jest
 					.spyOn(mySelfQuotaModule, 'mySelfQuota')
 					.mockResolvedValueOnce({ limit, used: quotaUsed })

--- a/src/carbonio-files-ui-common/views/components/FilesQuota.tsx
+++ b/src/carbonio-files-ui-common/views/components/FilesQuota.tsx
@@ -42,14 +42,14 @@ const InnerFilesQuota = ({
 		if (limit === 0) {
 			return t('quota.unlimitedSpace', '{{used}} of unlimited space', {
 				replace: {
-					used: humanFileSize(used)
+					used: humanFileSize(used, t)
 				}
 			});
 		}
 		return t('quota.limitedSpace', '{{used}} of {{limit}} used', {
 			replace: {
-				used: humanFileSize(used),
-				limit: humanFileSize(limit)
+				used: humanFileSize(used, t),
+				limit: humanFileSize(limit, t)
 			}
 		});
 	}, [limit, used, t]);

--- a/src/carbonio-files-ui-common/views/components/List.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/List.test.tsx
@@ -69,6 +69,7 @@ describe('List', () => {
 			node.mime_type = 'application/pdf';
 			node.type = NodeType.Application;
 			node.extension = 'pdf';
+			node.size = 5000;
 
 			const { user } = setup(<List nodes={[node]} mainList emptyListMessage={'Empty list'} />);
 			await user.dblClick(screen.getByText(node.name));
@@ -105,6 +106,7 @@ describe('List', () => {
 			node.mime_type = 'application/vnd.oasis.opendocument.text';
 			node.type = NodeType.Text;
 			node.extension = 'odt';
+			node.size = 5000;
 
 			const { user } = setup(<List nodes={[node]} mainList emptyListMessage={'Empty list'} />);
 			await user.dblClick(screen.getByText(node.name));

--- a/src/carbonio-files-ui-common/views/components/List.tsx
+++ b/src/carbonio-files-ui-common/views/components/List.tsx
@@ -370,7 +370,7 @@ export const List: React.VFC<ListProps> = ({
 					const item = {
 						filename: node.name,
 						extension: node.extension ?? undefined,
-						size: (node.size !== undefined && humanFileSize(node.size)) || undefined,
+						size: (node.size !== undefined && humanFileSize(node.size, t)) || undefined,
 						actions: getHeaderActions(t, setActiveNode, node, canUseDocs),
 						closeAction: {
 							id: 'close-action',

--- a/src/carbonio-files-ui-common/views/components/NodeDetails.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/NodeDetails.test.tsx
@@ -83,7 +83,7 @@ describe('Node Details', () => {
 			screen.getByText(formatDate(node.created_at, undefined, DATE_TIME_FORMAT))
 		).toBeVisible();
 		expect(screen.getByText(node.description)).toBeVisible();
-		expect(screen.getByText(humanFileSize(node.size))).toBeVisible();
+		expect(screen.getByText(humanFileSize(node.size, undefined))).toBeVisible();
 	});
 
 	test('Show folder info', () => {

--- a/src/carbonio-files-ui-common/views/components/NodeDetails.tsx
+++ b/src/carbonio-files-ui-common/views/components/NodeDetails.tsx
@@ -138,7 +138,7 @@ export const NodeDetails: React.VFC<NodeDetailsProps> = ({
 						<TextRowWithShim
 							loading={loading}
 							label={t('displayer.details.size', 'Size')}
-							content={(size !== undefined && humanFileSize(size)) || undefined}
+							content={(size !== undefined && humanFileSize(size, t)) || undefined}
 							shimmerWidth="5rem"
 						/>
 					)}

--- a/src/carbonio-files-ui-common/views/components/NodeListItem.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/NodeListItem.test.tsx
@@ -207,7 +207,7 @@ describe('Node List Item', () => {
 		const node = populateFile();
 		setup(<NodeListItem node={node} {...getMissingProps()} />);
 		expect(screen.getByText(node.extension as string)).toBeVisible();
-		expect(screen.getByText(humanFileSize(node.size))).toBeVisible();
+		expect(screen.getByText(humanFileSize(node.size, undefined))).toBeVisible();
 	});
 
 	test('owner is visible if different from logged user', () => {

--- a/src/carbonio-files-ui-common/views/components/NodeListItemUI.tsx
+++ b/src/carbonio-files-ui-common/views/components/NodeListItemUI.tsx
@@ -14,6 +14,7 @@ import {
 	Row,
 	Text
 } from '@zextras/carbonio-design-system';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { ContextualMenu, ContextualMenuProps } from './ContextualMenu';
@@ -74,6 +75,7 @@ export const NodeListItemUI = ({
 	nodeHoverBar,
 	size
 }: NodeListItemUIProps): React.JSX.Element => {
+	const [t] = useTranslation();
 	const preventTextSelection = useCallback<React.MouseEventHandler>((e: React.MouseEvent): void => {
 		if (e.detail > 1) {
 			e.preventDefault();
@@ -174,7 +176,7 @@ export const NodeListItemUI = ({
 									{size && (
 										<Padding left="small">
 											<CustomText color="gray1" disabled={disabled} size="small">
-												{humanFileSize(size)}
+												{humanFileSize(size, t)}
 											</CustomText>
 										</Padding>
 									)}

--- a/src/carbonio-files-ui-common/views/components/UploadDisplayerNode.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/UploadDisplayerNode.test.tsx
@@ -246,7 +246,7 @@ describe('Upload Displayer Node', () => {
 
 		await screen.findAllByText(uploadItem.name);
 		expect(screen.getByText(/size/i)).toBeVisible();
-		expect(screen.getByText(humanFileSize(uploadItem.file?.size || 0))).toBeVisible();
+		expect(screen.getByText(humanFileSize(uploadItem.file?.size || 0, undefined))).toBeVisible();
 	});
 
 	test('Size is hidden for folders', async () => {
@@ -259,7 +259,9 @@ describe('Upload Displayer Node', () => {
 
 		await screen.findAllByText(uploadItem.name);
 		expect(screen.queryByText(/size/i)).not.toBeInTheDocument();
-		expect(screen.queryByText(humanFileSize(uploadItem.file?.size || 0))).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(humanFileSize(uploadItem.file?.size || 0, undefined))
+		).not.toBeInTheDocument();
 	});
 
 	test('Content is hidden for files', async () => {

--- a/src/carbonio-files-ui-common/views/components/UploadDisplayerNode.tsx
+++ b/src/carbonio-files-ui-common/views/components/UploadDisplayerNode.tsx
@@ -140,7 +140,7 @@ export const UploadDisplayerNode = ({
 							<TextRowWithShim
 								loading={false}
 								label={t('displayer.details.size', 'Size')}
-								content={humanFileSize(uploadItem.file.size ?? 0)}
+								content={humanFileSize(uploadItem.file.size ?? 0, t)}
 								shimmerWidth="5rem"
 							/>
 						)}

--- a/src/carbonio-files-ui-common/views/components/UploadListItem.tsx
+++ b/src/carbonio-files-ui-common/views/components/UploadListItem.tsx
@@ -153,7 +153,7 @@ export const UploadListItem = React.memo<UploadListItemProps>(
 							>
 								{size !== undefined && (
 									<CustomText size="extrasmall" overflow="ellipsis" color="gray1">
-										{humanFileSize(size)}
+										{humanFileSize(size, t)}
 									</CustomText>
 								)}
 							</Container>

--- a/src/carbonio-files-ui-common/views/components/UploadListItemWrapper.test.tsx
+++ b/src/carbonio-files-ui-common/views/components/UploadListItemWrapper.test.tsx
@@ -67,7 +67,7 @@ describe('Upload List Item Wrapper', () => {
 		);
 		expect(destinationFolderItem).toBeVisible();
 		if (file.file) {
-			expect(screen.getByText(humanFileSize(file.file.size))).toBeVisible();
+			expect(screen.getByText(humanFileSize(file.file.size, undefined))).toBeVisible();
 		}
 		expect(screen.getByText(new RegExp(`${file.progress}\\s*%`, 'm'))).toBeVisible();
 		expect(screen.getByTestId(ICON_REGEXP.uploadLoading)).toBeVisible();

--- a/src/carbonio-files-ui-common/views/components/versioning/VersionRow.tsx
+++ b/src/carbonio-files-ui-common/views/components/versioning/VersionRow.tsx
@@ -283,7 +283,7 @@ export const VersionRow: React.VFC<{
 				columnStart={4}
 				columnEnd={5}
 			>
-				<CustomText>{humanFileSize(size)}</CustomText>
+				<CustomText>{humanFileSize(size, t)}</CustomText>
 			</GridItem>
 			<GridItem
 				data-testid={`version${version}-icons`}


### PR DESCRIPTION
Refs: FILES-821

---
Add translations:
- [x] "size.unitMeasure_B": "B"
- [x] "size.unitMeasure_KB": "KB"
- [x] "size.unitMeasure_MB": "MB"
- [x] "size.unitMeasure_GB": "GB"
- [x] "size.unitMeasure_TB": "TB"
- [x] "size.unitMeasure_PB": "PB"
- [x] "size.unitMeasure_EB": "EB"
- [x] "size.unitMeasure_ZB": "ZB"
- [x] "size.unitMeasure_YB": "YB"