### PR TITLE
fix: add sonarqube-scanner dependency to resolve CI permission issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
 				"jest-junit": "^16.0.0",
 				"msw": "^2.11.3",
 				"npm-check-updates": "^17.1.13",
+				"sonarqube-scanner": "^4.3.2",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.6.3"
 			}
@@ -8162,6 +8163,16 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/adm-zip": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -8607,6 +8618,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/axios": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+			"integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -8875,6 +8898,21 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
+		},
+		"node_modules/bare-events": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -12401,6 +12439,16 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -12592,6 +12640,13 @@
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
@@ -12880,13 +12935,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -12920,6 +12978,31 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
@@ -13708,6 +13791,16 @@
 				"obuf": "^1.0.0",
 				"readable-stream": "^2.0.1",
 				"wbuf": "^1.1.0"
+			}
+		},
+		"node_modules/hpagent": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+			"integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -16119,6 +16212,29 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/jsonparse": {
@@ -18785,6 +18901,16 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
+		"node_modules/properties-file": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/properties-file/-/properties-file-3.6.1.tgz",
+			"integrity": "sha512-9NUyJcxSqdWcJGRpPq6rT7exQbSQMPs0sK6KTvCJsLrTQRwq+hmt/wIB32ugNZmvEuSPyFO+y4nLK3vX34i5Wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18808,6 +18934,13 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",
@@ -20242,6 +20375,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/slugify": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+			"integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/snake-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -20272,6 +20415,82 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/sonarqube-scanner": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/sonarqube-scanner/-/sonarqube-scanner-4.3.2.tgz",
+			"integrity": "sha512-QI3t+yahqprjh8SWBMwQOEKLzrh35p5MQGyoIS8xm3wR2Q/CaQQeK4TEWpxGsLh2mpn1L1jNSHehSYuWdCpcvw==",
+			"dev": true,
+			"dependencies": {
+				"adm-zip": "0.5.16",
+				"axios": "1.12.2",
+				"commander": "13.1.0",
+				"fs-extra": "11.3.2",
+				"hpagent": "1.2.0",
+				"node-forge": "1.3.1",
+				"properties-file": "3.6.1",
+				"proxy-from-env": "1.1.0",
+				"semver": "7.7.2",
+				"slugify": "1.6.6",
+				"tar-stream": "3.1.7"
+			},
+			"bin": {
+				"sonar": "bin/sonar-scanner.js",
+				"sonar-scanner": "bin/sonar-scanner.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/b4a": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
 			}
 		},
 		"node_modules/source-map": {
@@ -20435,6 +20654,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/streamx": {
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
 			}
 		},
 		"node_modules/strict-event-emitter": {
@@ -20993,6 +21224,31 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/text-decoder/node_modules/b4a": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/text-extensions": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"jest-junit": "^16.0.0",
 		"msw": "^2.11.3",
 		"npm-check-updates": "^17.1.13",
+		"sonarqube-scanner": "^4.3.2",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.6.3"
 	},


### PR DESCRIPTION
Add sonarqube-scanner as devDependency to fix 'Permission denied' error when Jenkins runs npx sonar-scanner. This ensures the scanner is installed locally with proper permissions instead of being downloaded on-the-fly by npx.# Please enter the commit message for your changes. Lines starting