### PR TITLE
build(release): update jenkins-lib-ui to 1.0.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
  */
 
 library(
-    identifier: 'jenkins-lib-ui@1.0.12',
+    identifier: 'jenkins-lib-ui@1.0.13',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary

- Bumps `jenkins-lib-ui` from the current version to `1.0.13` in the Jenkinsfile

Part of IN-1095 JFrog cost optimization usage analysis and mitigation strategy.