### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sdk/package-lock.json
 *.tgz
 .env
 .vscode
+.worktrees/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,14 +5,14 @@
  */
 
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 
-zappPipeline(
+uiPipeline(
     timeout: 30
 )


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

### Changes

- Replaced `jenkins-lib-ui@1.0.13` library reference with `jenkins-lib-common@v2.4.3`
- Renamed `zappPipeline()` → `uiPipeline()` (parameters are identical)

No functional change to the pipeline behaviour.